### PR TITLE
Kitti datasets

### DIFF
--- a/alodataset/kitti_depth.py
+++ b/alodataset/kitti_depth.py
@@ -1,0 +1,240 @@
+import os
+import glob
+import warnings
+import numpy as np
+from PIL import Image
+from typing import List, Dict, Union
+from aloscene import Frame, Depth
+from alodataset import BaseDataset
+
+
+class KittiDepth(BaseDataset):
+    """
+    Parameters
+    ----------
+        subset: either 'train', 'val' or 'all'. If all, both val and train subset are considered.
+
+        return_depth: Either to include depth in the output or not.
+
+        custom_drives: Dictionnary (Keys (:str) registration date of the drive ('YYYY_MM_DD'). Values: (:List[Union[str, Dict]])
+                       either ids of drives or dictionnaries of drives of ids and specific files.
+                       Exemples: custom_drives = {'2011_09_28': ['0222', '0186']} will load all images from
+                                 2011_09_28_drive_0222_sync and 2011_09_28_drive_0186_sync.
+                                 custom_drives = {'2011_09_28': {'0222': ['0000000015', '0000000010']}} will load the two images.
+                       Ids should match the drives dates, otherwise the drive folder will be ignored.
+                       If None, all images from specified subset are loaded.
+
+        name: Key of database name in :attr:`alodataset_config.json` file, by default *kitti*.
+
+        main_folder: The main folder of input images, could be image_00, image_01, image_02 or image_03.
+
+        sample: Download (or not) a dataset sample from internet and replace the default dataset_dir.
+
+
+    Attributes
+    ----------
+        drives: List of paths to kitti drive folders.
+
+        drives_folders: List of paths to drives' parent forlders.
+
+
+    Exemples
+    --------
+        >>> # get all the dataset
+        >>> kitti_ds = KittiBaseDataset(
+                                subset='all',
+                                return_depth=True,
+                                )
+        >>> # get specific files from both val and train
+        >>> idsOfDrives = ['0001',  # drive from the training subset
+                           '0002',  # drive from the validation subset
+                          ]
+        >>> date = '2011_09_26'
+        >>> custom_drives = {date: idsOfDrives}
+        >>> kitti_ds = KittiBaseDataset(
+                                return_depth=True,
+                                custom_drives=custom_drives,
+                                )
+    """
+
+    VALID_SUBSETS = ["train", "val", "all"]
+    VALID_MAIN_FOLDERS = ["image_00", "image_01", "image_02", "image_03"]
+
+    def __init__(
+        self,
+        subset: str = "all",
+        return_depth: bool = True,
+        custom_drives: Union[Dict[str, List[str]], None] = None,
+        name: str = "kitti",
+        main_folder: str = "image_02",
+        sample: bool = False,
+        **kwargs,
+    ):
+        if sample:
+            raise NotImplementedError("Download option is not yet available for kitti.")
+        super(KittiDepth, self).__init__(name=name, **kwargs)
+
+        assert main_folder in self.VALID_MAIN_FOLDERS, f"main_folder should be in {self.VALID_MAIN_FOLDERS}"
+        assert subset in self.VALID_SUBSETS, f"subset should be one of {self.VALID_SUBSETS}"
+
+        self.main_folder = main_folder
+        self.return_depth = return_depth
+        self.drives = list()
+        self.drives_folders = list()
+        self.subset = subset
+        self.custom_drives = custom_drives
+        if self.subset == "all":
+            self.subset = self.VALID_SUBSETS[:2]
+        else:
+            self.subset = [self.subset]
+
+        for ss in self.subset:
+            self.drives_folders.append(os.path.join(self.dataset_dir, "images", ss))
+
+        if custom_drives is None:
+            for dfolder in self.drives_folders:
+                self.drives += glob.glob(os.path.join(dfolder, "*"))
+
+        else:
+            for date in custom_drives.keys():
+                for drive_id in custom_drives[date]:
+                    drive_exits = False
+                    if isinstance(drive_id, str):
+                        drive_name = self.get_drive_name(date, drive_id)
+                    elif isinstance(drive_id, dict):
+                        drive_name = self.get_drive_name(date, list(drive_id.keys())[0])
+                    else:
+                        raise AttributeError("invalid custom drive format")
+
+                    for dfolder in self.drives_folders:
+                        path_to_drive = os.path.join(dfolder, drive_name)
+                        if os.path.isdir(path_to_drive):
+                            drive_exits = True
+                            self.drives.append(path_to_drive)
+                            # break if path exists in the validation subset
+                            break
+                    if not drive_exits:
+                        print(
+                            f"Warning: no drive named {drive_name}. Drive id and date do not match or drive is not in the subset"
+                        )
+
+        for drive in self.drives:
+            if self.custom_drives:
+                basename = os.path.basename(drive)
+                date, drive_id = self.date_id_from_drive(basename)
+                if isinstance(self.custom_drives[date], list):
+                    self.items += self._get_paths_from_subdirs(drive)
+                if isinstance(self.custom_drives[date], dict):
+                    self.items += self._get_paths_from_subdirs(drive, self.custom_drives[date][drive_id])
+
+            else:
+                self.items += self._get_paths_from_subdirs(drive)
+
+        # making sure corresponding depth files exist
+        if self.return_depth:
+            replace_items = list()
+            for item in self.items:
+                depth_path = self.get_corresponding_depth(item)
+                if os.path.exists(depth_path):
+                    replace_items.append(item)
+            lost_items = len(self.items) - len(replace_items)
+            if lost_items > 0:
+                print(f"ground truth images not found for {lost_items} images")
+                self.items = replace_items
+
+        if self.custom_drives and not self.items:
+            raise AttributeError("Could not read any images from the given custom drives")
+
+    @classmethod
+    def from_yaml(cls, path: str, **kwargs):
+        """pass custom drives from a .yaml file"""
+        import yaml
+
+        with open(path, "r") as f:
+            custom_drives = yaml.load(f, Loader=yaml.FullLoader)
+        return cls(custom_drives=custom_drives, **kwargs)
+
+    @staticmethod
+    def depth_from_path(path: str) -> Depth:
+        """reads depth from the given path"""
+        depth = np.asarray(Image.open(path), dtype=np.int16)
+        return Depth(np.expand_dims(depth, 0))
+
+    def getitem(self, idx):
+        """Get the :mod:`Frame <aloscene.frame>` corresponds to *idx* index
+
+        Parameters
+        ----------
+        idx : int
+            Index of the frame to be returned
+
+        Returns
+        -------
+        :mod:`Frame <aloscene.frame>`
+            Frame with its corresponding depth
+        """
+        if self.sample:
+            return BaseDataset.__getitem__(self, idx)
+
+        image_path = self.items[idx]
+        frame = Frame(image_path)
+
+        if self.return_depth:
+            depth_path = self.get_corresponding_depth(image_path)
+            depth = self.depth_from_path(depth_path)
+            frame.append_depth(depth)
+
+        return frame
+
+    def get_corresponding_depth(self, path: str):
+        """
+        Args:
+            path to drive
+        Returns:
+            corresponding path to depth groud truth image.
+        """
+        fixed_dir = os.path.join("proj_depth", "groundtruth")
+        filename = os.path.basename(path)
+        driveAndSubset = os.path.join(*path.split(os.sep)[-5:-3])
+        return os.path.join(self.dataset_dir, "depth", driveAndSubset, fixed_dir, self.main_folder, filename)
+
+    def _get_paths_from_subdirs(
+        self, drive_path: str, filenames: Union[List[str], None] = None, extension: str = "png"
+    ) -> List[str]:
+        """return paths to images in drive_path/self.main_folder/data with the specified extension"""
+        assert extension in ["png", "jpg"], "unvalid extension: should be 'png' | 'jpg'"
+        main_path = os.path.join(drive_path, self.main_folder, "data")
+
+        if not os.path.exists(main_path):
+            drive = os.path.basename(drive_path)
+            print(f"main images folder {self.main_folder} not found for drive {drive}")
+        if filenames:
+            return [os.path.join(main_path, f"{filename}.{extension}") for filename in filenames]
+        else:
+            return sorted(glob.glob(os.path.join(main_path, f"*.{extension}")))
+
+    @staticmethod
+    def get_drive_name(date: str, drive_id: str) -> str:
+        """return the drive file name with the corresponding date and drive id"""
+        return date + "_drive_" + drive_id + "_sync"
+
+    @staticmethod
+    def date_id_from_drive(basename):
+        return basename[:10], basename[17:21]
+
+
+if __name__ == "__main__":
+    date = "2011_09_26"
+    idsOfDrives = [
+        "0001",  # sample from training subset
+        "0002",  # sample from validation subset
+    ]
+    custom_drives = {date: idsOfDrives}
+    kitti_ds = KittiDepth(
+        subset="all",
+        return_depth=True,
+        custom_drives=custom_drives,
+    )
+
+    for f, frames in enumerate(kitti_ds.train_loader(batch_size=2)):
+        frames = Frame.batch_list(frames)

--- a/alodataset/kitti_depth.py
+++ b/alodataset/kitti_depth.py
@@ -10,6 +10,7 @@ from alodataset import BaseDataset
 
 class KittiDepth(BaseDataset):
     """
+    Depth task from KITTI dataset.
     Parameters
     ----------
         subset: either 'train', 'val' or 'all'. If all, both val and train subset are considered.
@@ -41,7 +42,7 @@ class KittiDepth(BaseDataset):
     Exemples
     --------
         >>> # get all the dataset
-        >>> kitti_ds = KittiBaseDataset(
+        >>> kitti_ds = KittiDepth(
                                 subset='all',
                                 return_depth=True,
                                 )
@@ -51,7 +52,7 @@ class KittiDepth(BaseDataset):
                           ]
         >>> date = '2011_09_26'
         >>> custom_drives = {date: idsOfDrives}
-        >>> kitti_ds = KittiBaseDataset(
+        >>> kitti_ds = KittiDepth(
                                 return_depth=True,
                                 custom_drives=custom_drives,
                                 )
@@ -147,7 +148,19 @@ class KittiDepth(BaseDataset):
 
     @classmethod
     def from_yaml(cls, path: str, **kwargs):
-        """pass custom drives from a .yaml file"""
+        """Pass custom drives from a .yaml file.
+
+        Parameters
+        ----------
+
+        path: str
+            Path to the .yaml file.
+
+        Returns
+        -------
+        KittiDepth
+            KittiDepth dataset with custom drives.
+        """
         import yaml
 
         with open(path, "r") as f:
@@ -156,22 +169,33 @@ class KittiDepth(BaseDataset):
 
     @staticmethod
     def depth_from_path(path: str) -> Depth:
-        """reads depth from the given path"""
+        """Reads depth from the given path.
+
+        Parameters
+        ----------
+        path: str
+            Path to the depth file.
+
+        Returns
+        -------
+        Depth
+            Depth object.
+        """
         depth = np.asarray(Image.open(path), dtype=np.int16)
         return Depth(np.expand_dims(depth, 0))
 
     def getitem(self, idx):
-        """Get the :mod:`Frame <aloscene.frame>` corresponds to *idx* index
+        """Get the :mod:`Frame <aloscene.frame>` corresponds to *idx* index.
 
         Parameters
         ----------
         idx : int
-            Index of the frame to be returned
+            Index of the frame to be returned.
 
         Returns
         -------
         :mod:`Frame <aloscene.frame>`
-            Frame with its corresponding depth
+            Frame with its corresponding depth.
         """
         if self.sample:
             return BaseDataset.__getitem__(self, idx)
@@ -188,10 +212,17 @@ class KittiDepth(BaseDataset):
 
     def get_corresponding_depth(self, path: str):
         """
-        Args:
-            path to drive
+        Get the corresponding depth path from the given image path.
+
+        Parameters
+        ----------
+        path: str
+            Path to drive.
+
         Returns:
-            corresponding path to depth groud truth image.
+        --------
+        path: str
+            Corresponding path to depth groud truth image.
         """
         fixed_dir = os.path.join("proj_depth", "groundtruth")
         filename = os.path.basename(path)
@@ -201,7 +232,22 @@ class KittiDepth(BaseDataset):
     def _get_paths_from_subdirs(
         self, drive_path: str, filenames: Union[List[str], None] = None, extension: str = "png"
     ) -> List[str]:
-        """return paths to images in drive_path/self.main_folder/data with the specified extension"""
+        """Return paths to images in drive_path/self.main_folder/data with the specified extension.
+
+        Parameters
+        ----------
+        drive_path: str
+            Path to the drive.
+        filenames: list, optional
+            List of filenames to be returned. If None, all files are returned.
+        extension: str, optional
+            Extension of the files to be returned. Default is "png".
+
+        Returns
+        -------
+        list[str]
+            List of paths to images.
+        """
         assert extension in ["png", "jpg"], "unvalid extension: should be 'png' | 'jpg'"
         main_path = os.path.join(drive_path, self.main_folder, "data")
 
@@ -215,11 +261,35 @@ class KittiDepth(BaseDataset):
 
     @staticmethod
     def get_drive_name(date: str, drive_id: str) -> str:
-        """return the drive file name with the corresponding date and drive id"""
+        """Return the drive file name with the corresponding date and drive id.
+
+        Parameters
+        ----------
+        date: str
+            Date of the drive.
+        drive_id: str
+            Id of the drive.
+
+        Returns
+        -------
+        str
+            Drive name."""
         return date + "_drive_" + drive_id + "_sync"
 
     @staticmethod
     def date_id_from_drive(basename):
+        """Return the date and drive id from the drive name.
+
+        Parameters
+        ----------
+        basename: str
+            Drive name.
+
+        Returns
+        -------
+        str
+            Date and id of the drive.
+        """
         return basename[:10], basename[17:21]
 
 

--- a/alodataset/kitti_object.py
+++ b/alodataset/kitti_object.py
@@ -25,7 +25,9 @@ class KittiObjectDataset(BaseDataset, SplitMixin):
             self.items[idx] = {
                 "left": os.path.join(self.split_folder, f"image_2/{idx:06d}.png"),
                 "right": os.path.join(self.split_folder, f"image_3/{idx:06d}.png") if right_frame else None,
-                "label": os.path.join(self.split_folder, f"label_2/{idx:06d}.txt"),
+                "label": os.path.join(self.split_folder, f"label_2/{idx:06d}.txt")
+                if self.split == Split.TRAIN
+                else None,
                 "calib": os.path.join(self.split_folder, f"calib/{idx:06d}.txt"),
                 "left_context_1": os.path.join(self.split_folder, f"prev_2/{idx:06d}_01.png")
                 if context_images >= 1
@@ -64,25 +66,26 @@ class KittiObjectDataset(BaseDataset, SplitMixin):
         boxes2d = []
         boxes3d = []
         labels = []
-        with open(item["label"], "r") as f:
-            frame_info = f.readlines()
+        if item["label"] is not None:
+            with open(item["label"], "r") as f:
+                frame_info = f.readlines()
 
-            for line in frame_info:
-                line = line.split()
-                x, y, w, h = float(line[4]), float(line[5]), float(line[6]), float(line[7])
-                boxes2d.append([x, y, w, h])
-                labels.append(LABELS.index(line[0]))
-                boxes3d.append(
-                    [
-                        float(line[11]),
-                        float(line[12]) - float(line[8]) / 2,
-                        float(line[13]),
-                        float(line[9]),
-                        float(line[8]),
-                        float(line[10]),
-                        float(line[14]) + np.pi / 2,
-                    ]
-                )
+                for line in frame_info:
+                    line = line.split()
+                    x, y, w, h = float(line[4]), float(line[5]), float(line[6]), float(line[7])
+                    boxes2d.append([x, y, w, h])
+                    labels.append(LABELS.index(line[0]))
+                    boxes3d.append(
+                        [
+                            float(line[11]),
+                            float(line[12]) - float(line[8]) / 2,
+                            float(line[13]),
+                            float(line[9]),
+                            float(line[8]),
+                            float(line[10]),
+                            float(line[14]) + np.pi / 2,
+                        ]
+                    )
 
         labels = Labels(labels, labels_names=["boxes"])
 

--- a/alodataset/kitti_object.py
+++ b/alodataset/kitti_object.py
@@ -62,7 +62,6 @@ class KittiObjectDataset(BaseDataset, SplitMixin):
         frames["left"].append_cam_intrinsic(CameraIntrinsic(np.c_[calib["K_cam2"], np.zeros(3)]))
         frames["left"].append_cam_extrinsic(CameraExtrinsic(calib["T_cam2_rect"]))
 
-        # Try to calculate the boxes 3d of all objects
         boxes2d = []
         boxes3d = []
         labels = []
@@ -96,8 +95,7 @@ class KittiObjectDataset(BaseDataset, SplitMixin):
         labels = Labels(labels, labels_names=["boxes"])
 
         bounding_box = BoundingBoxes2D(boxes2d, boxes_format="xyxy", absolute=True, frame_size=size, labels=labels)
-        # boxes3d = [[0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.5]]
-        boxe3d = BoundingBoxes3D(boxes3d)  # maybe extrinsic ?
+        boxe3d = BoundingBoxes3D(boxes3d)
         frames["left"].append_boxes2d(bounding_box)
         frames["left"].append_boxes3d(boxe3d, name=str(idx))
 

--- a/alodataset/kitti_object.py
+++ b/alodataset/kitti_object.py
@@ -7,6 +7,8 @@ from alodataset import BaseDataset, Split, SplitMixin
 from aloscene import Frame, BoundingBoxes2D, Labels, BoundingBoxes3D
 from aloscene.camera_calib import CameraIntrinsic, CameraExtrinsic
 
+from alodataset.utils.kitti import load_calib_cam_to_cam
+
 
 class KittiObjectDataset(BaseDataset, SplitMixin):
     SPLIT_FOLDERS = {Split.TRAIN: "training", Split.TEST: "testing"}
@@ -59,7 +61,7 @@ class KittiObjectDataset(BaseDataset, SplitMixin):
             return BaseDataset.__getitem__(self, idx)
 
         item = self.items[idx]
-        calib = self._load_calib(item["calib"])
+        calib = load_calib_cam_to_cam(item["calib"])
         frames = {}
         frames["left"] = Frame(item["left"])
 
@@ -141,92 +143,10 @@ class KittiObjectDataset(BaseDataset, SplitMixin):
 
         return result
 
-    # https://github.com/utiasSTARS/pykitti/tree/master
-    def read_calib_file(self, filepath):
-        """Read in a calibration file and parse into a dictionary."""
-        data = {}
-
-        with open(filepath, "r") as f:
-            for line in f.readlines():
-                if line == "\n":
-                    continue
-                key, value = line.split(":", 1)
-                # The only non-float values in these files are dates, which
-                # we don't care about anyway
-                try:
-                    data[key] = np.array([float(x) for x in value.split()])
-                except ValueError:
-                    pass
-
-        return data
-
-    def _load_calib(self, calib_filepath):
-        """Load and compute intrinsic and extrinsic calibration parameters."""
-        # We'll build the calibration parameters as a dictionary, then
-        # convert it to a namedtuple to prevent it from being modified later
-        data = {}
-
-        # Load the calibration file
-        filedata = self.read_calib_file(calib_filepath)
-
-        # Create 3x4 projection matrices
-        P_rect_00 = np.reshape(filedata["P0"], (3, 4))
-        P_rect_10 = np.reshape(filedata["P1"], (3, 4))
-        P_rect_20 = np.reshape(filedata["P2"], (3, 4))
-        P_rect_30 = np.reshape(filedata["P3"], (3, 4))
-
-        data["P_rect_00"] = P_rect_00
-        data["P_rect_10"] = P_rect_10
-        data["P_rect_20"] = P_rect_20
-        data["P_rect_30"] = P_rect_30
-
-        # Compute the rectified extrinsics from cam0 to camN
-        T0 = np.eye(4)
-        T0[0, 3] = P_rect_00[0, 3] / P_rect_00[0, 0]
-        T1 = np.eye(4)
-        T1[0, 3] = P_rect_10[0, 3] / P_rect_10[0, 0]
-        T2 = np.eye(4)
-        T2[0, 3] = P_rect_20[0, 3] / P_rect_20[0, 0]
-        T3 = np.eye(4)
-        T3[0, 3] = P_rect_30[0, 3] / P_rect_30[0, 0]
-
-        data["T_cam0_rect"] = T0
-        data["T_cam1_rect"] = T1
-        data["T_cam2_rect"] = T2
-        data["T_cam3_rect"] = T3
-
-        # Compute the velodyne to rectified camera coordinate transforms
-        data["T_cam0_velo"] = np.reshape(filedata["Tr_velo_to_cam"], (3, 4))
-        data["T_cam0_velo"] = np.vstack([data["T_cam0_velo"], [0, 0, 0, 1]])
-        data["T_cam1_velo"] = T1.dot(data["T_cam0_velo"])
-        data["T_cam2_velo"] = T2.dot(data["T_cam0_velo"])
-        data["T_cam3_velo"] = T3.dot(data["T_cam0_velo"])
-
-        # Compute the camera intrinsics
-        data["K_cam0"] = P_rect_00[0:3, 0:3]
-        data["K_cam1"] = P_rect_10[0:3, 0:3]
-        data["K_cam2"] = P_rect_20[0:3, 0:3]
-        data["K_cam3"] = P_rect_30[0:3, 0:3]
-
-        # Compute the stereo baselines in meters by projecting the origin of
-        # each camera frame into the velodyne frame and computing the distances
-        # between them
-        p_cam = np.array([0, 0, 0, 1])
-        p_velo0 = np.linalg.inv(data["T_cam0_velo"]).dot(p_cam)
-        p_velo1 = np.linalg.inv(data["T_cam1_velo"]).dot(p_cam)
-        p_velo2 = np.linalg.inv(data["T_cam2_velo"]).dot(p_cam)
-        p_velo3 = np.linalg.inv(data["T_cam3_velo"]).dot(p_cam)
-
-        data["b_gray"] = np.linalg.norm(p_velo1 - p_velo0)  # gray baseline
-        data["b_rgb"] = np.linalg.norm(p_velo3 - p_velo2)  # rgb baseline
-
-        return data
-
 
 if __name__ == "__main__":
     from random import randint
 
     dataset = KittiObjectDataset(right_frame=True, context_images=2)
     obj = dataset.getitem(randint(0, len(dataset)))
-    # print(obj)
     obj["left"].get_view().render()

--- a/alodataset/kitti_object.py
+++ b/alodataset/kitti_object.py
@@ -19,7 +19,7 @@ class KittiObjectDataset(BaseDataset, SplitMixin):
         assert context_images >= 0 and context_images <= 3, "You can only get 3 frames before the main frame"
 
         if self.sample:
-            return
+            raise NotImplementedError("Sample is not implemented for KittiObjectDataset")
 
         self.split_folder = os.path.join(self.dataset_dir, self.get_split_folder())
         left_img_folder = os.path.join(self.split_folder, "image_2")

--- a/alodataset/kitti_object.py
+++ b/alodataset/kitti_object.py
@@ -18,6 +18,9 @@ class KittiObjectDataset(BaseDataset, SplitMixin):
 
         assert context_images >= 0 and context_images <= 3, "You can only get 3 frames before the main frame"
 
+        if self.sample:
+            return
+
         self.split_folder = os.path.join(self.dataset_dir, self.get_split_folder())
         left_img_folder = os.path.join(self.split_folder, "image_2")
         n_samples = len(os.listdir(left_img_folder))
@@ -55,6 +58,10 @@ class KittiObjectDataset(BaseDataset, SplitMixin):
         return len(self.items)
 
     def getitem(self, idx) -> Dict[str, Frame]:
+
+        if self.sample:
+            return BaseDataset.__getitem__(self, idx)
+        
         item = self.items[idx]
         calib = self._load_calib(item["calib"])
         frames = {}

--- a/alodataset/kitti_object.py
+++ b/alodataset/kitti_object.py
@@ -7,11 +7,10 @@ from alodataset import BaseDataset, Split, SplitMixin
 from aloscene import Frame, BoundingBoxes2D, Labels, BoundingBoxes3D
 from aloscene.camera_calib import CameraIntrinsic, CameraExtrinsic
 
-LABELS = ["Car", "Van", "Truck", "Pedestrian", "Person_sitting", "Cyclist", "Tram", "Misc", "DontCare"]
-
 
 class KittiObjectDataset(BaseDataset, SplitMixin):
     SPLIT_FOLDERS = {Split.TRAIN: "training", Split.TEST: "testing"}
+    LABELS = ["Car", "Van", "Truck", "Pedestrian", "Person_sitting", "Cyclist", "Tram", "Misc", "DontCare"]
 
     def __init__(self, name="kitti_object", right_frame=False, context_images=3, **kwargs):
         super().__init__(name=name, **kwargs)
@@ -87,7 +86,7 @@ class KittiObjectDataset(BaseDataset, SplitMixin):
                     line = line.split()
                     x, y, w, h = float(line[4]), float(line[5]), float(line[6]), float(line[7])
                     boxes2d.append([x, y, w, h])
-                    labels.append(LABELS.index(line[0]))
+                    labels.append(self.LABELS.index(line[0]))
                     boxes3d.append(
                         [
                             float(line[11]),

--- a/alodataset/kitti_object.py
+++ b/alodataset/kitti_object.py
@@ -78,11 +78,17 @@ class KittiObjectDataset(BaseDataset, SplitMixin):
                     boxes3d.append(
                         [
                             float(line[11]),
+                            # The center of the 3d box on Kitty is the center of the bottom face. We need to
+                            # move it up by half the height of the box to correspond to the center of the box.
+                            # Check kitti_tracking devkit for more info.
                             float(line[12]) - float(line[8]) / 2,
                             float(line[13]),
                             float(line[9]),
                             float(line[8]),
                             float(line[10]),
+                            # The rotation of the 3d box on Kitty is based on the X axis. We need to rotate it
+                            # to have same the rotation wanted by BoundingBoxes3D.
+                            # Check kitti_object devkit for more info.
                             float(line[14]) + np.pi / 2,
                         ]
                     )
@@ -179,7 +185,7 @@ class KittiObjectDataset(BaseDataset, SplitMixin):
 if __name__ == "__main__":
     from random import randint
 
-    dataset = KittiObjectDataset(right_frame=True, context_images=2)
+    dataset = KittiObjectDataset(right_frame=False, context_images=0)
     obj = dataset.getitem(randint(0, len(dataset)))
     print(obj)
     obj["left"].get_view().render()

--- a/alodataset/kitti_object.py
+++ b/alodataset/kitti_object.py
@@ -53,9 +53,6 @@ class KittiObjectDataset(BaseDataset, SplitMixin):
                 else None,
             }
 
-    def __len__(self):
-        return len(self.items)
-
     def getitem(self, idx) -> Dict[str, Frame]:
 
         if self.sample:

--- a/alodataset/kitti_object.py
+++ b/alodataset/kitti_object.py
@@ -61,7 +61,7 @@ class KittiObjectDataset(BaseDataset, SplitMixin):
 
         if self.sample:
             return BaseDataset.__getitem__(self, idx)
-        
+
         item = self.items[idx]
         calib = self._load_calib(item["calib"])
         frames = {}

--- a/alodataset/kitti_odometry.py
+++ b/alodataset/kitti_odometry.py
@@ -281,7 +281,6 @@ class KittiOdometryDataset(BaseDataset, SplitMixin):
 if __name__ == "__main__":
     from random import randint
 
-    odo = KittiOdometryDataset(sequences=["00", "01"], sequence_skip=40, skip=28, sequence_size=5)
-    r = odo.getitem(randint(0, len(odo)))
-    print(r["left"])
-    r["left"].get_view().render()
+    dataset = KittiOdometryDataset(sequences=["00", "01"], sequence_skip=40, skip=28, sequence_size=5)
+    obj = dataset.getitem(randint(0, len(dataset)))
+    obj["left"].get_view().render()

--- a/alodataset/kitti_odometry.py
+++ b/alodataset/kitti_odometry.py
@@ -1,49 +1,116 @@
 import os
 import torch
 import numpy as np
+from typing import List, Dict, Any
 
-from alodataset import BaseDataset, SplitMixin
+from alodataset import BaseDataset, SplitMixin, Split
 from aloscene import Frame, Pose, CameraIntrinsic
 
 
+def sequence_index(start, seq_size, skip):
+    end = start + (seq_size - 1) * (skip + 1)
+    return np.linspace(start, end, seq_size).astype(int).tolist()
+
+
+def sequence_indices(n_samples, seq_size, skip, seq_skip):
+    for start in range(0, n_samples - (seq_size - 1) * (skip + 1), seq_skip + 1):
+        yield sequence_index(start, seq_size, skip)
+
+
 class KittiOdometryDataset(BaseDataset, SplitMixin):
-    def __init__(self, name="kitti_odometry", sequance=0, grayscale=True, right_frame=True, **kwargs):
+    def __init__(
+        self,
+        name="kitti_odometry",
+        sequences=None,
+        grayscale=True,
+        right_frame=True,
+        sequence_size=3,
+        skip=1,
+        sequence_skip=1,
+        **kwargs,
+    ):
         super().__init__(name=name, **kwargs)
+
+        self.grayscale = grayscale
+        self.right_frame = right_frame
+        self.sequence_size = sequence_size
+        self.skip = skip
+        self.sequence_skip = sequence_skip
 
         if self.sample:
             return
 
-        datasets = os.path.join(self.dataset_dir)
+        self.dataset_dir = os.path.join(self.dataset_dir, "dataset")
 
-        # Create intrinsic with file calib.txt
-        with open(os.path.join(self.dataset_dir, "sequences", f"{sequance:02d}", "calib.txt"), "r") as file:
-            self.calib = file.readlines()
-            left_intrinsic = np.array([float(x) for x in self.calib[0].split()[1:]]).reshape(3, 4)
-            right_intrinsic = np.array([float(x) for x in self.calib[1].split()[1:]]).reshape(3, 4)
-            self.left_intrinsic = CameraIntrinsic(left_intrinsic)
-            self.right_intrinsic = CameraIntrinsic(right_intrinsic)
+        self.sequences = self._load_sequences(sequences)
 
-        # Load poses of the sequence
-        self.poses = None
-        if sequance <= 10:
-            with open(os.path.join(datasets, "poses", f"{sequance:02d}.txt"), "r") as file:
-                self.poses = file.readlines()
+        self.items: Dict[Any, Any] = {"seq_params": {}}
 
-        # Load times of each frame
-        with open(os.path.join(self.dataset_dir, "sequences", f"{sequance:02d}", "times.txt"), "r") as file:
-            self.times = file.readlines()
+        for seq in self.sequences:
+            # Conpute sequence parameters once and store them in the items dictionary.
+            self.items["seq_params"][seq] = {}
+            seq_params = self.items["seq_params"][seq]
 
-        self.folders = {
-            "left": os.path.join(datasets, "sequences", f"{sequance:02d}", f"image_{0 if grayscale else 2}"),
-            "right": os.path.join(datasets, "sequences", f"{sequance:02d}", f"image_{1 if grayscale else 3}")
-            if right_frame
-            else None,
-        }
+            # Exploit data from calib.txt
+            calib = self._load_calib(os.path.join(self.dataset_dir, "sequences", seq, "calib.txt"))
+
+            # Register sequence parameters
+            seq_params["baseline"] = calib["b_gray" if self.grayscale else "b_rgb"]
+            seq_params["left_intrinsic"] = CameraIntrinsic(np.c_[calib[f"K_cam{0 if grayscale else 2}"], np.zeros(3)])
+            if right_frame:
+                seq_params["right_intrinsic"] = CameraIntrinsic(
+                    np.c_[calib[f"K_cam{1 if grayscale else 3}"], np.zeros(3)]
+                )
+            with open(os.path.join(self.dataset_dir, "sequences", seq, "times.txt"), "r") as f:
+                seq_params["times"] = [float(x) for x in f.readlines()]
+
+            if int(seq) < 11:
+                with open(os.path.join(self.dataset_dir, "poses", f"{seq}.txt"), "r") as f:
+                    seq_params["poses"] = f.readlines()
+
+            # Compute all the items.
+            sequence_size = len(seq_params["times"])
+
+            # Compute sequence indices
+            temporal_sequences = sequence_indices(sequence_size, self.sequence_size, self.skip, self.sequence_skip)
+            self.items.update(
+                {
+                    len(self.items)
+                    - 1
+                    + idx: {
+                        "sequence": seq,
+                        "temporal_sequence": temporal_seq,
+                    }
+                    for idx, temporal_seq in enumerate(temporal_sequences)
+                }
+            )
 
     def __len__(self):
         if self.sample:
             return len(self.items)
         return len(self.times)
+
+    def _load_sequences(self, sequences) -> List[str]:
+        loaded_sequences = []
+
+        if sequences is None:
+            for seq in sorted(os.listdir(os.path.join(self.dataset_dir, "sequences"))):
+                loaded_sequences.append(seq)
+        elif isinstance(sequences, int):
+            if not os.path.exists(os.path.join(self.dataset_dir, "sequences", f"{sequences:02d}")):
+                raise ValueError(f"Sequence {sequences:02d} does not exist")
+            loaded_sequences.append(f"{sequences:02d}")
+        elif isinstance(sequences, str):
+            if not os.path.exists(os.path.join(self.dataset_dir, "sequences", sequences)):
+                raise ValueError(f"Sequence {sequences} does not exist")
+            loaded_sequences.append(sequences)
+        elif isinstance(sequences, list):
+            for seq in sequences:
+                if not os.path.exists(os.path.join(self.dataset_dir, "sequences", seq)):
+                    raise ValueError(f"Sequence {seq} does not exist")
+                loaded_sequences.append(seq)
+
+        return loaded_sequences
 
     def getitem(self, idx: int):
         """
@@ -63,22 +130,144 @@ class KittiOdometryDataset(BaseDataset, SplitMixin):
         if self.sample:
             return BaseDataset.__getitem__(self, idx)
 
-        frames = {
-            "left": Frame(os.path.join(self.folders["left"], f"{idx:06d}.png")),
-        }
+        item = self.items[idx]
+        print("item", item)
 
-        frames["left"].baseline = 0.54
-        frames["left"].append_cam_intrinsic(self.left_intrinsic)
-        frames["left"].timestamp = float(self.times[idx])
+        left = []
+        right = []
+        times = []
+        poses = []
+        sequence = item["sequence"]
+        sequence_params = self.items["seq_params"][sequence]
 
-        if self.poses:
-            frames["left"].append_pose(
-                Pose(torch.Tensor([float(x) for x in self.poses[idx].split(" ")] + [0, 0, 0, 1]).reshape(4, 4))
+        for seq in item["temporal_sequence"]:
+
+            times.append(float(sequence_params["times"][seq]))
+
+            left.append(
+                Frame(
+                    os.path.join(
+                        self.dataset_dir,
+                        "sequences",
+                        sequence,
+                        f"image_{0 if self.grayscale else 2}",
+                        f"{seq:06d}.png",
+                    )
+                ).temporal()
             )
 
-        if self.folders["right"] is not None:
-            frames["right"] = Frame(os.path.join(self.folders["right"], f"{idx:06d}.png"))
-            frames["right"].baseline = 0.54
-            frames["right"].append_cam_intrinsic(self.right_intrinsic)
+            if self.split == Split.TRAIN:
+                pose = Pose(
+                    torch.Tensor([float(x) for x in sequence_params["poses"][seq].split(" ")] + [0, 0, 0, 1]).reshape(
+                        4, 4
+                    )
+                )
+                poses.append(pose)
+
+            if self.right_frame:
+                right.append(
+                    Frame(
+                        os.path.join(
+                            self.dataset_dir,
+                            "sequences",
+                            sequence,
+                            f"image_{1 if self.grayscale else 3}",
+                            f"{seq:06d}.png",
+                        )
+                    ).temporal()
+                )
+
+        frames: Dict[str, Frame] = {}
+        frames["left"] = torch.cat(left, dim=0)
+        frames["left"].timestamp = times
+        frames["left"].baseline = sequence_params["baseline"]
+        frames["left"].append_cam_intrinsic(sequence_params["left_intrinsic"])
+        if poses:
+            frames["left"].append_pose(poses)
+
+        if self.right_frame:
+            frames["right"] = torch.cat(right, dim=0)
+            frames["right"].timestamp = times
+            frames["right"].baseline = sequence_params["baseline"]
+            frames["right"].append_cam_intrinsic(sequence_params["right_intrinsic"])
 
         return frames
+
+    # https://github.com/utiasSTARS/pykitti/tree/master
+    def read_calib_file(self, filepath):
+        """Read in a calibration file and parse into a dictionary."""
+        data = {}
+
+        with open(filepath, "r") as f:
+            for line in f.readlines():
+                key, value = line.split(":", 1)
+                # The only non-float values in these files are dates, which
+                # we don't care about anyway
+                try:
+                    data[key] = np.array([float(x) for x in value.split()])
+                except ValueError:
+                    pass
+
+        return data
+
+    def _load_calib(self, calib_filepath):
+        """Load and compute intrinsic and extrinsic calibration parameters."""
+        # We'll build the calibration parameters as a dictionary, then
+        # convert it to a namedtuple to prevent it from being modified later
+        data = {}
+
+        # Load the calibration file
+        filedata = self.read_calib_file(calib_filepath)
+
+        # Create 3x4 projection matrices
+        P_rect_00 = np.reshape(filedata["P0"], (3, 4))
+        P_rect_10 = np.reshape(filedata["P1"], (3, 4))
+        P_rect_20 = np.reshape(filedata["P2"], (3, 4))
+        P_rect_30 = np.reshape(filedata["P3"], (3, 4))
+
+        data["P_rect_00"] = P_rect_00
+        data["P_rect_10"] = P_rect_10
+        data["P_rect_20"] = P_rect_20
+        data["P_rect_30"] = P_rect_30
+
+        # Compute the rectified extrinsics from cam0 to camN
+        T1 = np.eye(4)
+        T1[0, 3] = P_rect_10[0, 3] / P_rect_10[0, 0]
+        T2 = np.eye(4)
+        T2[0, 3] = P_rect_20[0, 3] / P_rect_20[0, 0]
+        T3 = np.eye(4)
+        T3[0, 3] = P_rect_30[0, 3] / P_rect_30[0, 0]
+
+        # Compute the velodyne to rectified camera coordinate transforms
+        data["T_cam0_velo"] = np.reshape(filedata["Tr"], (3, 4))
+        data["T_cam0_velo"] = np.vstack([data["T_cam0_velo"], [0, 0, 0, 1]])
+        data["T_cam1_velo"] = T1.dot(data["T_cam0_velo"])
+        data["T_cam2_velo"] = T2.dot(data["T_cam0_velo"])
+        data["T_cam3_velo"] = T3.dot(data["T_cam0_velo"])
+
+        # Compute the camera intrinsics
+        data["K_cam0"] = P_rect_00[0:3, 0:3]
+        data["K_cam1"] = P_rect_10[0:3, 0:3]
+        data["K_cam2"] = P_rect_20[0:3, 0:3]
+        data["K_cam3"] = P_rect_30[0:3, 0:3]
+
+        # Compute the stereo baselines in meters by projecting the origin of
+        # each camera frame into the velodyne frame and computing the distances
+        # between them
+        p_cam = np.array([0, 0, 0, 1])
+        p_velo0 = np.linalg.inv(data["T_cam0_velo"]).dot(p_cam)
+        p_velo1 = np.linalg.inv(data["T_cam1_velo"]).dot(p_cam)
+        p_velo2 = np.linalg.inv(data["T_cam2_velo"]).dot(p_cam)
+        p_velo3 = np.linalg.inv(data["T_cam3_velo"]).dot(p_cam)
+
+        data["b_gray"] = np.linalg.norm(p_velo1 - p_velo0)  # gray baseline
+        data["b_rgb"] = np.linalg.norm(p_velo3 - p_velo2)  # rgb baseline
+
+        return data
+
+
+if __name__ == "__main__":
+    odo = KittiOdometryDataset(sequences=["00", "01"], sequence_skip=40, skip=28)
+    r = odo.getitem(0)
+    print(r)
+    r["left"].get_view().render()

--- a/alodataset/kitti_odometry.py
+++ b/alodataset/kitti_odometry.py
@@ -93,9 +93,6 @@ class KittiOdometryDataset(BaseDataset, SplitMixin):
                 }
             )
 
-    def __len__(self):
-        return len(self.items)
-
     def _load_sequences(self, sequences) -> List[str]:
         loaded_sequences = []
 

--- a/alodataset/kitti_odometry.py
+++ b/alodataset/kitti_odometry.py
@@ -38,7 +38,7 @@ class KittiOdometryDataset(BaseDataset, SplitMixin):
         self.sequence_skip = sequence_skip
 
         if self.sample:
-            return
+            raise NotImplementedError("Sample mode is not implemented for KittiOdometryDataset")
 
         self.dataset_dir = os.path.join(self.dataset_dir, "dataset")
 

--- a/alodataset/kitti_odometry.py
+++ b/alodataset/kitti_odometry.py
@@ -1,0 +1,84 @@
+import os
+import torch
+import numpy as np
+
+from alodataset import BaseDataset, SplitMixin
+from aloscene import Frame, Pose, CameraIntrinsic
+
+
+class KittiOdometryDataset(BaseDataset, SplitMixin):
+    def __init__(self, name="kitti_odometry", sequance=0, grayscale=True, right_frame=True, **kwargs):
+        super().__init__(name=name, **kwargs)
+
+        if self.sample:
+            return
+
+        datasets = os.path.join(self.dataset_dir)
+
+        # Create intrinsic with file calib.txt
+        with open(os.path.join(self.dataset_dir, "sequences", f"{sequance:02d}", "calib.txt"), "r") as file:
+            self.calib = file.readlines()
+            left_intrinsic = np.array([float(x) for x in self.calib[0].split()[1:]]).reshape(3, 4)
+            right_intrinsic = np.array([float(x) for x in self.calib[1].split()[1:]]).reshape(3, 4)
+            self.left_intrinsic = CameraIntrinsic(left_intrinsic)
+            self.right_intrinsic = CameraIntrinsic(right_intrinsic)
+
+        # Load poses of the sequence
+        self.poses = None
+        if sequance <= 10:
+            with open(os.path.join(datasets, "poses", f"{sequance:02d}.txt"), "r") as file:
+                self.poses = file.readlines()
+
+        # Load times of each frame
+        with open(os.path.join(self.dataset_dir, "sequences", f"{sequance:02d}", "times.txt"), "r") as file:
+            self.times = file.readlines()
+
+        self.folders = {
+            "left": os.path.join(datasets, "sequences", f"{sequance:02d}", f"image_{0 if grayscale else 2}"),
+            "right": os.path.join(datasets, "sequences", f"{sequance:02d}", f"image_{1 if grayscale else 3}")
+            if right_frame
+            else None,
+        }
+
+    def __len__(self):
+        if self.sample:
+            return len(self.items)
+        return len(self.times)
+
+    def getitem(self, idx: int):
+        """
+        Loads a single frame from the dataset.
+
+        Parameters
+        ----------
+        idx : int
+            Index of the frame to load.
+
+        Returns
+        -------
+        Dict[str, Frame]
+            Dictionary with the loaded frame and pose.
+        """
+
+        if self.sample:
+            return BaseDataset.__getitem__(self, idx)
+
+        frames = {
+            "left": Frame(os.path.join(self.folders["left"], f"{idx:06d}.png")),
+        }
+
+        frames["left"].baseline = 0.54
+        frames["left"].append_cam_intrinsic(self.left_intrinsic)
+        frames["left"].timestamp = float(self.times[idx])
+
+        if self.poses:
+            frames["left"].append_pose(
+                Pose(torch.Tensor([float(x) for x in self.poses[idx].split(" ")] + [0, 0, 0, 1]).reshape(4, 4))
+            )
+
+        if self.folders["right"] is not None:
+            frames["right"] = Frame(os.path.join(self.folders["right"], f"{idx:06d}.png"))
+            frames["right"].baseline = 0.54
+            frames["right"].append_cam_intrinsic(self.right_intrinsic)
+
+        return frames

--- a/alodataset/kitti_odometry.py
+++ b/alodataset/kitti_odometry.py
@@ -127,7 +127,7 @@ class KittiOdometryDataset(BaseDataset, SplitMixin):
 
         return loaded_sequences
 
-    def getitem(self, idx: int):
+    def getitem(self, idx: int) -> Dict[str, Frame]:
         """
         Loads a single frame from the dataset.
 

--- a/alodataset/kitti_odometry.py
+++ b/alodataset/kitti_odometry.py
@@ -4,7 +4,7 @@ import numpy as np
 from typing import List, Dict, Any
 
 from alodataset import BaseDataset, SplitMixin, Split
-from aloscene import Frame, Pose, CameraIntrinsic
+from aloscene import Frame, Pose, CameraIntrinsic, CameraExtrinsic
 
 
 def sequence_index(start, seq_size, skip):
@@ -181,9 +181,8 @@ class KittiOdometryDataset(BaseDataset, SplitMixin):
                     ).temporal()
                 )
 
-        frames: Dict[str, Frame] = {}
+        frames = {}
         frames["left"] = torch.cat(left, dim=0)
-        # time are incorrect
         frames["left"].timestamp = item["times"]
         frames["left"].baseline = self.seq_params["baseline"]
         frames["left"].append_cam_intrinsic(self.seq_params["left_intrinsic"])

--- a/alodataset/kitti_odometry.py
+++ b/alodataset/kitti_odometry.py
@@ -44,70 +44,81 @@ class KittiOdometryDataset(BaseDataset, SplitMixin):
 
         self.sequences = self._load_sequences(sequences)
 
-        self.items: Dict[Any, Any] = {"seq_params": {}}
+        self.items: Dict[Any, Any] = {}
+
+        self.seq_params = {}
 
         for seq in self.sequences:
-            # Conpute sequence parameters once and store them in the items dictionary.
-            self.items["seq_params"][seq] = {}
-            seq_params = self.items["seq_params"][seq]
 
             # Exploit data from calib.txt
             calib = self._load_calib(os.path.join(self.dataset_dir, "sequences", seq, "calib.txt"))
 
             # Register sequence parameters
-            seq_params["baseline"] = calib["b_gray" if self.grayscale else "b_rgb"]
-            seq_params["left_intrinsic"] = CameraIntrinsic(np.c_[calib[f"K_cam{0 if grayscale else 2}"], np.zeros(3)])
+            self.seq_params["baseline"] = calib["b_gray" if self.grayscale else "b_rgb"]
+            self.seq_params["left_intrinsic"] = CameraIntrinsic(
+                np.c_[calib[f"K_cam{0 if grayscale else 2}"], np.zeros(3)]
+            )
             if right_frame:
-                seq_params["right_intrinsic"] = CameraIntrinsic(
+                self.seq_params["right_intrinsic"] = CameraIntrinsic(
                     np.c_[calib[f"K_cam{1 if grayscale else 3}"], np.zeros(3)]
                 )
-            with open(os.path.join(self.dataset_dir, "sequences", seq, "times.txt"), "r") as f:
-                seq_params["times"] = [float(x) for x in f.readlines()]
 
+            with open(os.path.join(self.dataset_dir, "sequences", seq, "times.txt"), "r") as f:
+                times = [float(x) for x in f.readlines()]
+
+            poses = None
             if int(seq) < 11:
                 with open(os.path.join(self.dataset_dir, "poses", f"{seq}.txt"), "r") as f:
-                    seq_params["poses"] = f.readlines()
+                    poses = f.readlines()
 
             # Compute all the items.
-            sequence_size = len(seq_params["times"])
+            sequence_size = len(times)
 
             # Compute sequence indices
             temporal_sequences = sequence_indices(sequence_size, self.sequence_size, self.skip, self.sequence_skip)
             self.items.update(
                 {
                     len(self.items)
-                    - 1
                     + idx: {
                         "sequence": seq,
                         "temporal_sequence": temporal_seq,
+                        "times": [times[x] for x in temporal_seq],
+                        "poses": [poses[x] for x in temporal_seq] if poses else None,
                     }
                     for idx, temporal_seq in enumerate(temporal_sequences)
                 }
             )
 
     def __len__(self):
-        if self.sample:
-            return len(self.items)
-        return len(self.times)
+        return len(self.items)
 
     def _load_sequences(self, sequences) -> List[str]:
         loaded_sequences = []
 
         if sequences is None:
             for seq in sorted(os.listdir(os.path.join(self.dataset_dir, "sequences"))):
-                loaded_sequences.append(seq)
+                if (int(seq) <= 10 and self.split == Split.TRAIN) or (int(seq) >= 11 and self.split == Split.VAL):
+                    loaded_sequences.append(seq)
         elif isinstance(sequences, int):
             if not os.path.exists(os.path.join(self.dataset_dir, "sequences", f"{sequences:02d}")):
                 raise ValueError(f"Sequence {sequences:02d} does not exist")
+            if (sequences <= 10 and self.split == Split.VAL) or (sequences >= 11 and self.split == Split.TRAIN):
+                raise ValueError(f"Sequence {sequences:02d} is not in the {self.split} split")
             loaded_sequences.append(f"{sequences:02d}")
         elif isinstance(sequences, str):
             if not os.path.exists(os.path.join(self.dataset_dir, "sequences", sequences)):
                 raise ValueError(f"Sequence {sequences} does not exist")
+            if (int(sequences) <= 10 and self.split == Split.VAL) or (
+                int(sequences) >= 11 and self.split == Split.TRAIN
+            ):
+                raise ValueError(f"Sequence {sequences} is not in the {self.split} split")
             loaded_sequences.append(sequences)
         elif isinstance(sequences, list):
             for seq in sequences:
                 if not os.path.exists(os.path.join(self.dataset_dir, "sequences", seq)):
                     raise ValueError(f"Sequence {seq} does not exist")
+                if (int(seq) <= 10 and self.split == Split.VAL) or (int(seq) >= 11 and self.split == Split.TRAIN):
+                    raise ValueError(f"Sequence {seq} is not in the {self.split} split")
                 loaded_sequences.append(seq)
 
         return loaded_sequences
@@ -131,18 +142,13 @@ class KittiOdometryDataset(BaseDataset, SplitMixin):
             return BaseDataset.__getitem__(self, idx)
 
         item = self.items[idx]
-        print("item", item)
 
         left = []
         right = []
-        times = []
         poses = []
-        sequence = item["sequence"]
-        sequence_params = self.items["seq_params"][sequence]
+        sequence: str = item["sequence"]  # Number of the sequence
 
-        for seq in item["temporal_sequence"]:
-
-            times.append(float(sequence_params["times"][seq]))
+        for id, seq in enumerate(item["temporal_sequence"]):
 
             left.append(
                 Frame(
@@ -158,9 +164,7 @@ class KittiOdometryDataset(BaseDataset, SplitMixin):
 
             if self.split == Split.TRAIN:
                 pose = Pose(
-                    torch.Tensor([float(x) for x in sequence_params["poses"][seq].split(" ")] + [0, 0, 0, 1]).reshape(
-                        4, 4
-                    )
+                    torch.Tensor([float(x) for x in item["poses"][id].split(" ")] + [0, 0, 0, 1]).reshape(4, 4)
                 )
                 poses.append(pose)
 
@@ -179,17 +183,18 @@ class KittiOdometryDataset(BaseDataset, SplitMixin):
 
         frames: Dict[str, Frame] = {}
         frames["left"] = torch.cat(left, dim=0)
-        frames["left"].timestamp = times
-        frames["left"].baseline = sequence_params["baseline"]
-        frames["left"].append_cam_intrinsic(sequence_params["left_intrinsic"])
+        # time are incorrect
+        frames["left"].timestamp = item["times"]
+        frames["left"].baseline = self.seq_params["baseline"]
+        frames["left"].append_cam_intrinsic(self.seq_params["left_intrinsic"])
         if poses:
             frames["left"].append_pose(poses)
 
         if self.right_frame:
             frames["right"] = torch.cat(right, dim=0)
-            frames["right"].timestamp = times
-            frames["right"].baseline = sequence_params["baseline"]
-            frames["right"].append_cam_intrinsic(sequence_params["right_intrinsic"])
+            frames["right"].timestamp = item["times"]
+            frames["right"].baseline = self.seq_params["baseline"]
+            frames["right"].append_cam_intrinsic(self.seq_params["right_intrinsic"])
 
         return frames
 
@@ -269,5 +274,5 @@ class KittiOdometryDataset(BaseDataset, SplitMixin):
 if __name__ == "__main__":
     odo = KittiOdometryDataset(sequences=["00", "01"], sequence_skip=40, skip=28)
     r = odo.getitem(0)
-    print(r)
-    r["left"].get_view().render()
+    print(r["left"])
+    # r["left"].get_view().render()

--- a/alodataset/kitti_odometry.py
+++ b/alodataset/kitti_odometry.py
@@ -6,15 +6,7 @@ from typing import List, Dict, Any
 from alodataset import BaseDataset, SplitMixin, Split
 from aloscene import Frame, Pose, CameraIntrinsic, CameraExtrinsic
 
-
-def sequence_index(start, seq_size, skip):
-    end = start + (seq_size - 1) * (skip + 1)
-    return np.linspace(start, end, seq_size).astype(int).tolist()
-
-
-def sequence_indices(n_samples, seq_size, skip, seq_skip):
-    for start in range(0, n_samples - (seq_size - 1) * (skip + 1), seq_skip + 1):
-        yield sequence_index(start, seq_size, skip)
+from alodataset.utils.kitti import load_calib_cam_to_cam, sequence_indices
 
 
 class KittiOdometryDataset(BaseDataset, SplitMixin):
@@ -51,7 +43,7 @@ class KittiOdometryDataset(BaseDataset, SplitMixin):
         for seq in self.sequences:
 
             # Exploit data from calib.txt
-            calib = self._load_calib(os.path.join(self.dataset_dir, "sequences", seq, "calib.txt"))
+            calib = load_calib_cam_to_cam(os.path.join(self.dataset_dir, "sequences", seq, "calib.txt"))
 
             self.seq_params[seq] = {}
 
@@ -197,85 +189,6 @@ class KittiOdometryDataset(BaseDataset, SplitMixin):
             frames["right"].timestamp = item["times"]
 
         return frames
-
-    # https://github.com/utiasSTARS/pykitti/tree/master
-    def read_calib_file(self, filepath):
-        """Read in a calibration file and parse into a dictionary."""
-        data = {}
-
-        with open(filepath, "r") as f:
-            for line in f.readlines():
-                key, value = line.split(":", 1)
-                # The only non-float values in these files are dates, which
-                # we don't care about anyway
-                try:
-                    data[key] = np.array([float(x) for x in value.split()])
-                except ValueError:
-                    pass
-
-        return data
-
-    def _load_calib(self, calib_filepath):
-        """Load and compute intrinsic and extrinsic calibration parameters."""
-        # We'll build the calibration parameters as a dictionary, then
-        # convert it to a namedtuple to prevent it from being modified later
-        data = {}
-
-        # Load the calibration file
-        filedata = self.read_calib_file(calib_filepath)
-
-        # Create 3x4 projection matrices
-        P_rect_00 = np.reshape(filedata["P0"], (3, 4))
-        P_rect_10 = np.reshape(filedata["P1"], (3, 4))
-        P_rect_20 = np.reshape(filedata["P2"], (3, 4))
-        P_rect_30 = np.reshape(filedata["P3"], (3, 4))
-
-        data["P_rect_00"] = P_rect_00
-        data["P_rect_10"] = P_rect_10
-        data["P_rect_20"] = P_rect_20
-        data["P_rect_30"] = P_rect_30
-
-        # Compute the rectified extrinsics from cam0 to camN
-        T0 = np.eye(4)
-        T0[0, 3] = P_rect_00[0, 3] / P_rect_00[0, 0]
-        T1 = np.eye(4)
-        T1[0, 3] = P_rect_10[0, 3] / P_rect_10[0, 0]
-        T2 = np.eye(4)
-        T2[0, 3] = P_rect_20[0, 3] / P_rect_20[0, 0]
-        T3 = np.eye(4)
-        T3[0, 3] = P_rect_30[0, 3] / P_rect_30[0, 0]
-
-        data["T_cam0_rect"] = T0
-        data["T_cam1_rect"] = T1
-        data["T_cam2_rect"] = T2
-        data["T_cam3_rect"] = T3
-
-        # Compute the velodyne to rectified camera coordinate transforms
-        data["T_cam0_velo"] = np.reshape(filedata["Tr"], (3, 4))
-        data["T_cam0_velo"] = np.vstack([data["T_cam0_velo"], [0, 0, 0, 1]])
-        data["T_cam1_velo"] = T1.dot(data["T_cam0_velo"])
-        data["T_cam2_velo"] = T2.dot(data["T_cam0_velo"])
-        data["T_cam3_velo"] = T3.dot(data["T_cam0_velo"])
-
-        # Compute the camera intrinsics
-        data["K_cam0"] = P_rect_00[0:3, 0:3]
-        data["K_cam1"] = P_rect_10[0:3, 0:3]
-        data["K_cam2"] = P_rect_20[0:3, 0:3]
-        data["K_cam3"] = P_rect_30[0:3, 0:3]
-
-        # Compute the stereo baselines in meters by projecting the origin of
-        # each camera frame into the velodyne frame and computing the distances
-        # between them
-        p_cam = np.array([0, 0, 0, 1])
-        p_velo0 = np.linalg.inv(data["T_cam0_velo"]).dot(p_cam)
-        p_velo1 = np.linalg.inv(data["T_cam1_velo"]).dot(p_cam)
-        p_velo2 = np.linalg.inv(data["T_cam2_velo"]).dot(p_cam)
-        p_velo3 = np.linalg.inv(data["T_cam3_velo"]).dot(p_cam)
-
-        data["b_gray"] = np.linalg.norm(p_velo1 - p_velo0)  # gray baseline
-        data["b_rgb"] = np.linalg.norm(p_velo3 - p_velo2)  # rgb baseline
-
-        return data
 
 
 if __name__ == "__main__":

--- a/alodataset/kitti_road.py
+++ b/alodataset/kitti_road.py
@@ -20,7 +20,7 @@ class KittiRoadDataset(BaseDataset, SplitMixin):
         assert obj == "road" or (obj == "lane" and environement == "um"), "Type must be 'road' or 'lane'"
 
         if self.sample:
-            return
+            raise NotImplementedError("Sample mode is not implemented for KittiRoadDataset")
 
         self.obj = obj
         self.grayscale = grayscale

--- a/alodataset/kitti_road.py
+++ b/alodataset/kitti_road.py
@@ -1,0 +1,146 @@
+import os
+import numpy as np
+import cv2
+
+from alodataset import BaseDataset, Split, SplitMixin
+from aloscene import Frame, Mask, Labels
+from aloscene.camera_calib import CameraIntrinsic, CameraExtrinsic
+
+LABELS = ["Car", "Van", "Truck", "Pedestrian", "Person_sitting", "Cyclist", "Tram", "Misc", "DontCare"]
+
+
+class KittiRoadDataset(BaseDataset, SplitMixin):
+    SPLIT_FOLDERS = {Split.TRAIN: "training", Split.TEST: "testing"}
+
+    def __init__(self, name="kitti_road", right_frame=False, grayscale=False, environement="um", obj="road", **kwargs):
+        super().__init__(name=name, **kwargs)
+
+        assert environement in ["um", "umm", "uu"], "Environement must be in ['um', 'umm', 'uu']"
+        assert obj == "road" or (obj == "lane" and environement == "um"), "Type must be 'road' or 'lane'"
+
+        self.obj = obj
+        self.grayscale = grayscale
+
+        self.split_folder = os.path.join(self.dataset_dir, "data_road", self.get_split_folder())
+        left_img_folder = os.path.join(self.split_folder, "image_2")
+        n_samples = len([file for file in os.listdir(left_img_folder) if file.startswith(f"{environement}_")])
+        self.extentions_dir = os.path.join(self.split_folder, self.get_split_folder())
+
+        self.items = {}
+        for idx in range(n_samples):
+            self.items[idx] = {
+                "left": os.path.join(self.extentions_dir, f"image_0/{environement}_{idx:06d}.png")
+                if grayscale
+                else os.path.join(self.split_folder, f"image_2/{environement}_{idx:06d}.png"),
+                "right": os.path.join(self.extentions_dir, f"image_{1 if grayscale else 3}/{idx:06d}.png")
+                if right_frame
+                else None,
+                "ground_truth": os.path.join(self.split_folder, f"gt_image_2/{environement}_{obj}_{idx:06d}.png")
+                if self.split == Split.TRAIN and grayscale is False
+                else None,
+                "calib": os.path.join(self.split_folder, f"calib/{environement}_{idx:06d}.txt"),
+            }
+
+    def __len__(self):
+        return len(self.items)
+
+    def getitem(self, idx):
+        item = self.items[idx]
+        calib = self._load_calib(item["calib"])
+
+        frames = {}
+        if item["right"] is not None:
+            frames["right"] = Frame(item["right"])
+            frames["right"].append_cam_extrinsic(CameraExtrinsic(calib[f"T_cam{1 if self.grayscale else 3}_rect"]))
+            frames["right"].append_cam_intrinsic(CameraIntrinsic(calib[f"K_cam{1 if self.grayscale else 3}"]))
+        frames["left"] = Frame(item["left"])
+        frames["left"].append_cam_intrinsic(
+            CameraIntrinsic(np.c_[calib[f"K_cam{0 if self.grayscale else 2}"], np.zeros(3)])
+        )
+        frames["left"].append_cam_extrinsic(CameraExtrinsic(calib[f"T_cam{0 if self.grayscale else 2}_rect"]))
+
+        if item["ground_truth"] is not None:
+            names = [self.obj, "valid_area", "invalid_area"]
+            color_codes = [[0, 255], [2, 255], [2, 0]]
+            # Cv2 loads images in BGR format
+            ground_truth = cv2.imread(item["ground_truth"], cv2.IMREAD_UNCHANGED)
+            print(ground_truth.shape, ground_truth)
+            for name, color_code in zip(names, color_codes):
+                area = ~np.array(ground_truth[:, :, color_code[0]] == color_code[1])
+                print(area.shape, area)
+                area = np.expand_dims(area, axis=0)
+                area = Mask(area, names=("C", "H", "W"))
+                frames["left"].append_mask(area, name=name)
+
+        return frames
+
+    # https://github.com/utiasSTARS/pykitti/tree/master
+    def read_calib_file(self, filepath):
+        """Read in a calibration file and parse into a dictionary."""
+        data = {}
+
+        with open(filepath, "r") as f:
+            for line in f.readlines():
+                if line == "\n":
+                    continue
+                key, value = line.split(":", 1)
+                # The only non-float values in these files are dates, which
+                # we don't care about anyway
+                try:
+                    data[key] = np.array([float(x) for x in value.split()])
+                except ValueError:
+                    pass
+
+        return data
+
+    def _load_calib(self, calib_filepath):
+        """Load and compute intrinsic and extrinsic calibration parameters."""
+        # We'll build the calibration parameters as a dictionary, then
+        # convert it to a namedtuple to prevent it from being modified later
+        data = {}
+
+        # Load the calibration file
+        filedata = self.read_calib_file(calib_filepath)
+
+        # Create 3x4 projection matrices
+        P_rect_00 = np.reshape(filedata["P0"], (3, 4))
+        P_rect_10 = np.reshape(filedata["P1"], (3, 4))
+        P_rect_20 = np.reshape(filedata["P2"], (3, 4))
+        P_rect_30 = np.reshape(filedata["P3"], (3, 4))
+
+        data["P_rect_00"] = P_rect_00
+        data["P_rect_10"] = P_rect_10
+        data["P_rect_20"] = P_rect_20
+        data["P_rect_30"] = P_rect_30
+
+        # Compute the rectified extrinsics from cam0 to camN
+        T0 = np.eye(4)
+        T0[0, 3] = P_rect_00[0, 3] / P_rect_00[0, 0]
+        T1 = np.eye(4)
+        T1[0, 3] = P_rect_10[0, 3] / P_rect_10[0, 0]
+        T2 = np.eye(4)
+        T2[0, 3] = P_rect_20[0, 3] / P_rect_20[0, 0]
+        T3 = np.eye(4)
+        T3[0, 3] = P_rect_30[0, 3] / P_rect_30[0, 0]
+
+        data["T_cam0_rect"] = T0
+        data["T_cam1_rect"] = T1
+        data["T_cam2_rect"] = T2
+        data["T_cam3_rect"] = T3
+
+        # Compute the camera intrinsics
+        data["K_cam0"] = P_rect_00[0:3, 0:3]
+        data["K_cam1"] = P_rect_10[0:3, 0:3]
+        data["K_cam2"] = P_rect_20[0:3, 0:3]
+        data["K_cam3"] = P_rect_30[0:3, 0:3]
+
+        return data
+
+
+if __name__ == "__main__":
+    from random import randint
+
+    dataset = KittiRoadDataset()
+    obj = dataset.getitem(randint(0, len(dataset)))
+    print("final", obj["left"].shape, obj)
+    obj["left"].get_view().render()

--- a/alodataset/kitti_road.py
+++ b/alodataset/kitti_road.py
@@ -47,17 +47,20 @@ class KittiRoadDataset(BaseDataset, SplitMixin):
     def getitem(self, idx):
         item = self.items[idx]
         calib = self._load_calib(item["calib"])
-
         frames = {}
+
         if item["right"] is not None:
             frames["right"] = Frame(item["right"])
             frames["right"].append_cam_extrinsic(CameraExtrinsic(calib[f"T_cam{1 if self.grayscale else 3}_rect"]))
             frames["right"].append_cam_intrinsic(CameraIntrinsic(calib[f"K_cam{1 if self.grayscale else 3}"]))
+            frames["right"].baseline = calib["b_gray" if self.grayscale else "b_rgb"]
+
         frames["left"] = Frame(item["left"])
         frames["left"].append_cam_intrinsic(
             CameraIntrinsic(np.c_[calib[f"K_cam{0 if self.grayscale else 2}"], np.zeros(3)])
         )
         frames["left"].append_cam_extrinsic(CameraExtrinsic(calib[f"T_cam{0 if self.grayscale else 2}_rect"]))
+        frames["left"].baseline = calib["b_gray" if self.grayscale else "b_rgb"]
 
         if item["ground_truth"] is not None:
             names = [self.obj, "valid_area", "invalid_area"]
@@ -126,11 +129,30 @@ class KittiRoadDataset(BaseDataset, SplitMixin):
         data["T_cam2_rect"] = T2
         data["T_cam3_rect"] = T3
 
+        # Compute the velodyne to rectified camera coordinate transforms
+        data['T_cam0_velo'] = np.reshape(filedata['Tr_velo_to_cam'], (3, 4))
+        data['T_cam0_velo'] = np.vstack([data['T_cam0_velo'], [0, 0, 0, 1]])
+        data['T_cam1_velo'] = T1.dot(data['T_cam0_velo'])
+        data['T_cam2_velo'] = T2.dot(data['T_cam0_velo'])
+        data['T_cam3_velo'] = T3.dot(data['T_cam0_velo'])
+
         # Compute the camera intrinsics
         data["K_cam0"] = P_rect_00[0:3, 0:3]
         data["K_cam1"] = P_rect_10[0:3, 0:3]
         data["K_cam2"] = P_rect_20[0:3, 0:3]
         data["K_cam3"] = P_rect_30[0:3, 0:3]
+
+        # Compute the stereo baselines in meters by projecting the origin of
+        # each camera frame into the velodyne frame and computing the distances
+        # between them
+        p_cam = np.array([0, 0, 0, 1])
+        p_velo0 = np.linalg.inv(data['T_cam0_velo']).dot(p_cam)
+        p_velo1 = np.linalg.inv(data['T_cam1_velo']).dot(p_cam)
+        p_velo2 = np.linalg.inv(data['T_cam2_velo']).dot(p_cam)
+        p_velo3 = np.linalg.inv(data['T_cam3_velo']).dot(p_cam)
+
+        data['b_gray'] = np.linalg.norm(p_velo1 - p_velo0)  # gray baseline
+        data['b_rgb'] = np.linalg.norm(p_velo3 - p_velo2)   # rgb baseline
 
         return data
 

--- a/alodataset/kitti_road.py
+++ b/alodataset/kitti_road.py
@@ -1,6 +1,7 @@
 import os
 import numpy as np
 import cv2
+from typing import Dict
 
 from alodataset import BaseDataset, Split, SplitMixin
 from aloscene import Frame, Mask
@@ -47,7 +48,7 @@ class KittiRoadDataset(BaseDataset, SplitMixin):
     def __len__(self):
         return len(self.items)
 
-    def getitem(self, idx):
+    def getitem(self, idx) -> Dict[str, Frame]:
 
         if self.sample:
             return BaseDataset.__getitem__(self, idx)
@@ -136,11 +137,11 @@ class KittiRoadDataset(BaseDataset, SplitMixin):
         data["T_cam3_rect"] = T3
 
         # Compute the velodyne to rectified camera coordinate transforms
-        data['T_cam0_velo'] = np.reshape(filedata['Tr_velo_to_cam'], (3, 4))
-        data['T_cam0_velo'] = np.vstack([data['T_cam0_velo'], [0, 0, 0, 1]])
-        data['T_cam1_velo'] = T1.dot(data['T_cam0_velo'])
-        data['T_cam2_velo'] = T2.dot(data['T_cam0_velo'])
-        data['T_cam3_velo'] = T3.dot(data['T_cam0_velo'])
+        data["T_cam0_velo"] = np.reshape(filedata["Tr_velo_to_cam"], (3, 4))
+        data["T_cam0_velo"] = np.vstack([data["T_cam0_velo"], [0, 0, 0, 1]])
+        data["T_cam1_velo"] = T1.dot(data["T_cam0_velo"])
+        data["T_cam2_velo"] = T2.dot(data["T_cam0_velo"])
+        data["T_cam3_velo"] = T3.dot(data["T_cam0_velo"])
 
         # Compute the camera intrinsics
         data["K_cam0"] = P_rect_00[0:3, 0:3]
@@ -152,13 +153,13 @@ class KittiRoadDataset(BaseDataset, SplitMixin):
         # each camera frame into the velodyne frame and computing the distances
         # between them
         p_cam = np.array([0, 0, 0, 1])
-        p_velo0 = np.linalg.inv(data['T_cam0_velo']).dot(p_cam)
-        p_velo1 = np.linalg.inv(data['T_cam1_velo']).dot(p_cam)
-        p_velo2 = np.linalg.inv(data['T_cam2_velo']).dot(p_cam)
-        p_velo3 = np.linalg.inv(data['T_cam3_velo']).dot(p_cam)
+        p_velo0 = np.linalg.inv(data["T_cam0_velo"]).dot(p_cam)
+        p_velo1 = np.linalg.inv(data["T_cam1_velo"]).dot(p_cam)
+        p_velo2 = np.linalg.inv(data["T_cam2_velo"]).dot(p_cam)
+        p_velo3 = np.linalg.inv(data["T_cam3_velo"]).dot(p_cam)
 
-        data['b_gray'] = np.linalg.norm(p_velo1 - p_velo0)  # gray baseline
-        data['b_rgb'] = np.linalg.norm(p_velo3 - p_velo2)   # rgb baseline
+        data["b_gray"] = np.linalg.norm(p_velo1 - p_velo0)  # gray baseline
+        data["b_rgb"] = np.linalg.norm(p_velo3 - p_velo2)  # rgb baseline
 
         return data
 

--- a/alodataset/kitti_road.py
+++ b/alodataset/kitti_road.py
@@ -18,6 +18,9 @@ class KittiRoadDataset(BaseDataset, SplitMixin):
         assert environement in ["um", "umm", "uu"], "Environement must be in ['um', 'umm', 'uu']"
         assert obj == "road" or (obj == "lane" and environement == "um"), "Type must be 'road' or 'lane'"
 
+        if self.sample:
+            return
+
         self.obj = obj
         self.grayscale = grayscale
 
@@ -45,6 +48,9 @@ class KittiRoadDataset(BaseDataset, SplitMixin):
         return len(self.items)
 
     def getitem(self, idx):
+
+        if self.sample:
+            return BaseDataset.__getitem__(self, idx)
         item = self.items[idx]
         calib = self._load_calib(item["calib"])
         frames = {}

--- a/alodataset/kitti_road.py
+++ b/alodataset/kitti_road.py
@@ -7,6 +7,7 @@ from alodataset import BaseDataset, Split, SplitMixin
 from aloscene import Frame, Mask
 from aloscene.camera_calib import CameraIntrinsic, CameraExtrinsic
 
+from alodataset.utils.kitti import load_calib_cam_to_cam
 
 class KittiRoadDataset(BaseDataset, SplitMixin):
     SPLIT_FOLDERS = {Split.TRAIN: "training", Split.TEST: "testing"}
@@ -48,7 +49,7 @@ class KittiRoadDataset(BaseDataset, SplitMixin):
         if self.sample:
             return BaseDataset.__getitem__(self, idx)
         item = self.items[idx]
-        calib = self._load_calib(item["calib"])
+        calib = load_calib_cam_to_cam(item["calib"])
         frames = {}
 
         if item["right"] is not None:
@@ -77,92 +78,10 @@ class KittiRoadDataset(BaseDataset, SplitMixin):
 
         return frames
 
-    # https://github.com/utiasSTARS/pykitti/tree/master
-    def read_calib_file(self, filepath):
-        """Read in a calibration file and parse into a dictionary."""
-        data = {}
-
-        with open(filepath, "r") as f:
-            for line in f.readlines():
-                if line == "\n":
-                    continue
-                key, value = line.split(":", 1)
-                # The only non-float values in these files are dates, which
-                # we don't care about anyway
-                try:
-                    data[key] = np.array([float(x) for x in value.split()])
-                except ValueError:
-                    pass
-
-        return data
-
-    def _load_calib(self, calib_filepath):
-        """Load and compute intrinsic and extrinsic calibration parameters."""
-        # We'll build the calibration parameters as a dictionary, then
-        # convert it to a namedtuple to prevent it from being modified later
-        data = {}
-
-        # Load the calibration file
-        filedata = self.read_calib_file(calib_filepath)
-
-        # Create 3x4 projection matrices
-        P_rect_00 = np.reshape(filedata["P0"], (3, 4))
-        P_rect_10 = np.reshape(filedata["P1"], (3, 4))
-        P_rect_20 = np.reshape(filedata["P2"], (3, 4))
-        P_rect_30 = np.reshape(filedata["P3"], (3, 4))
-
-        data["P_rect_00"] = P_rect_00
-        data["P_rect_10"] = P_rect_10
-        data["P_rect_20"] = P_rect_20
-        data["P_rect_30"] = P_rect_30
-
-        # Compute the rectified extrinsics from cam0 to camN
-        T0 = np.eye(4)
-        T0[0, 3] = P_rect_00[0, 3] / P_rect_00[0, 0]
-        T1 = np.eye(4)
-        T1[0, 3] = P_rect_10[0, 3] / P_rect_10[0, 0]
-        T2 = np.eye(4)
-        T2[0, 3] = P_rect_20[0, 3] / P_rect_20[0, 0]
-        T3 = np.eye(4)
-        T3[0, 3] = P_rect_30[0, 3] / P_rect_30[0, 0]
-
-        data["T_cam0_rect"] = T0
-        data["T_cam1_rect"] = T1
-        data["T_cam2_rect"] = T2
-        data["T_cam3_rect"] = T3
-
-        # Compute the velodyne to rectified camera coordinate transforms
-        data["T_cam0_velo"] = np.reshape(filedata["Tr_velo_to_cam"], (3, 4))
-        data["T_cam0_velo"] = np.vstack([data["T_cam0_velo"], [0, 0, 0, 1]])
-        data["T_cam1_velo"] = T1.dot(data["T_cam0_velo"])
-        data["T_cam2_velo"] = T2.dot(data["T_cam0_velo"])
-        data["T_cam3_velo"] = T3.dot(data["T_cam0_velo"])
-
-        # Compute the camera intrinsics
-        data["K_cam0"] = P_rect_00[0:3, 0:3]
-        data["K_cam1"] = P_rect_10[0:3, 0:3]
-        data["K_cam2"] = P_rect_20[0:3, 0:3]
-        data["K_cam3"] = P_rect_30[0:3, 0:3]
-
-        # Compute the stereo baselines in meters by projecting the origin of
-        # each camera frame into the velodyne frame and computing the distances
-        # between them
-        p_cam = np.array([0, 0, 0, 1])
-        p_velo0 = np.linalg.inv(data["T_cam0_velo"]).dot(p_cam)
-        p_velo1 = np.linalg.inv(data["T_cam1_velo"]).dot(p_cam)
-        p_velo2 = np.linalg.inv(data["T_cam2_velo"]).dot(p_cam)
-        p_velo3 = np.linalg.inv(data["T_cam3_velo"]).dot(p_cam)
-
-        data["b_gray"] = np.linalg.norm(p_velo1 - p_velo0)  # gray baseline
-        data["b_rgb"] = np.linalg.norm(p_velo3 - p_velo2)  # rgb baseline
-
-        return data
-
 
 if __name__ == "__main__":
     from random import randint
 
     dataset = KittiRoadDataset()
     obj = dataset.getitem(randint(0, len(dataset)))
-    print("final", obj["left"].shape, obj)
     obj["left"].get_view().render()

--- a/alodataset/kitti_road.py
+++ b/alodataset/kitti_road.py
@@ -3,7 +3,7 @@ import numpy as np
 import cv2
 
 from alodataset import BaseDataset, Split, SplitMixin
-from aloscene import Frame, Mask, Labels
+from aloscene import Frame, Mask
 from aloscene.camera_calib import CameraIntrinsic, CameraExtrinsic
 
 LABELS = ["Car", "Van", "Truck", "Pedestrian", "Person_sitting", "Cyclist", "Tram", "Misc", "DontCare"]
@@ -64,10 +64,8 @@ class KittiRoadDataset(BaseDataset, SplitMixin):
             color_codes = [[0, 255], [2, 255], [2, 0]]
             # Cv2 loads images in BGR format
             ground_truth = cv2.imread(item["ground_truth"], cv2.IMREAD_UNCHANGED)
-            print(ground_truth.shape, ground_truth)
             for name, color_code in zip(names, color_codes):
                 area = ~np.array(ground_truth[:, :, color_code[0]] == color_code[1])
-                print(area.shape, area)
                 area = np.expand_dims(area, axis=0)
                 area = Mask(area, names=("C", "H", "W"))
                 frames["left"].append_mask(area, name=name)

--- a/alodataset/kitti_road.py
+++ b/alodataset/kitti_road.py
@@ -7,8 +7,6 @@ from alodataset import BaseDataset, Split, SplitMixin
 from aloscene import Frame, Mask
 from aloscene.camera_calib import CameraIntrinsic, CameraExtrinsic
 
-LABELS = ["Car", "Van", "Truck", "Pedestrian", "Person_sitting", "Cyclist", "Tram", "Misc", "DontCare"]
-
 
 class KittiRoadDataset(BaseDataset, SplitMixin):
     SPLIT_FOLDERS = {Split.TRAIN: "training", Split.TEST: "testing"}
@@ -44,9 +42,6 @@ class KittiRoadDataset(BaseDataset, SplitMixin):
                 else None,
                 "calib": os.path.join(self.split_folder, f"calib/{environement}_{idx:06d}.txt"),
             }
-
-    def __len__(self):
-        return len(self.items)
 
     def getitem(self, idx) -> Dict[str, Frame]:
 

--- a/alodataset/kitti_semantic.py
+++ b/alodataset/kitti_semantic.py
@@ -9,9 +9,6 @@ from aloscene import Frame, Mask, Labels, BoundingBoxes2D
 from aloscene.camera_calib import CameraIntrinsic, CameraExtrinsic
 
 
-LABELS = ["Car", "Van", "Truck", "Pedestrian", "Person_sitting", "Cyclist", "Tram", "Misc", "DontCare"]
-
-
 class KittiSemanticDataset(BaseDataset, SplitMixin):
     SPLIT_FOLDERS = {Split.TRAIN: "training", Split.TEST: "testing"}
 
@@ -74,9 +71,6 @@ class KittiSemanticDataset(BaseDataset, SplitMixin):
                 if self.split == Split.TRAIN
                 else None,
             }
-
-    def __len__(self):
-        return len(self.items)
 
     def rgb2id(self, color: Union[list, np.ndarray]):
         if isinstance(color, np.ndarray) and len(color.shape) == 3:

--- a/alodataset/kitti_semantic.py
+++ b/alodataset/kitti_semantic.py
@@ -1,0 +1,190 @@
+import os
+import numpy as np
+import cv2
+import torch
+from typing import Union
+
+from alodataset import BaseDataset, Split, SplitMixin
+from aloscene import Frame, Mask, Labels, BoundingBoxes2D
+from aloscene.camera_calib import CameraIntrinsic, CameraExtrinsic
+
+
+LABELS = ["Car", "Van", "Truck", "Pedestrian", "Person_sitting", "Cyclist", "Tram", "Misc", "DontCare"]
+
+
+class KittiSemanticDataset(BaseDataset, SplitMixin):
+    SPLIT_FOLDERS = {Split.TRAIN: "training", Split.TEST: "testing"}
+
+    def __init__(self, name="kitti_semantic", **kwargs):
+        super().__init__(name=name, **kwargs)
+
+        self.split_folder = os.path.join(self.dataset_dir, self.get_split_folder())
+        left_img_folder = os.path.join(self.split_folder, "image_2")
+        n_samples = len([file for file in os.listdir(left_img_folder)])
+
+        self.category = [
+            ("unlabeled", 0),
+            ("ego vehicle", 1),
+            ("rectification border", 2),
+            ("out of roi", 3),
+            ("static", 4),
+            ("dynamic", 5),
+            ("ground", 6),
+            ("road", 7),
+            ("sidewalk", 8),
+            ("parking", 9),
+            ("rail track", 10),
+            ("building", 11),
+            ("wall", 12),
+            ("fence", 13),
+            ("guard rail", 14),
+            ("bridge", 15),
+            ("tunnel", 16),
+            ("pole", 17),
+            ("polegroup", 18),
+            ("traffic light", 19),
+            ("traffic sign", 20),
+            ("vegetation", 21),
+            ("terrain", 22),
+            ("sky", 23),
+            ("person", 24),
+            ("rider", 25),
+            ("car", 26),
+            ("truck", 27),
+            ("bus", 28),
+            ("caravan", 29),
+            ("trailer", 30),
+            ("train", 31),
+            ("motorcycle", 32),
+            ("bicycle", 33),
+            ("license plate", -1),
+        ]
+
+        self.items = {}
+        for idx in range(n_samples):
+            self.items[idx] = {
+                "left": os.path.join(self.split_folder, f"image_2/{idx:06d}_10.png"),
+                "instance": os.path.join(self.split_folder, f"instance/{idx:06d}_10.png")
+                if self.split == Split.TRAIN
+                else None,
+                "semantic": os.path.join(self.split_folder, f"semantic/{idx:06d}_10.png")
+                if self.split == Split.TRAIN
+                else None,
+            }
+
+    def __len__(self):
+        return len(self.items)
+
+    def rgb2id(self, color: Union[list, np.ndarray]):
+        if isinstance(color, np.ndarray) and len(color.shape) == 3:
+            if color.dtype == np.uint8:
+                color = color.astype(np.int32)
+            return color[:, :, 0] + 256 * color[:, :, 1] + 256 * 256 * color[:, :, 2]
+        return int(color[0] + 256 * color[1] + 256 * 256 * color[2])
+
+    def getitem(self, idx):
+        item = self.items[idx]
+
+        frames = {}
+        frames["left"] = Frame(item["left"])
+
+        if item["instance"] is not None:
+            instance = cv2.imread(item["instance"], cv2.IMREAD_UNCHANGED)
+            instance = np.array(instance, dtype=np.int32)
+            instance_gt = instance % 256
+            instance_gt = instance_gt.astype(np.uint8)
+            semantic_gt = instance // 256
+            semantic_gt = semantic_gt.astype(np.uint8)
+
+            masks = []
+            labels_list = []
+
+            # For each instance of each category
+            for cat in self.category:
+                for unique in np.unique(instance_gt[semantic_gt == cat[1]]):
+                    # Check for the object we want and the instance we want
+                    object = (semantic_gt == cat[1]) & (instance_gt == unique)
+                    masks.append(Mask(np.expand_dims(object, axis=0), names=("N", "H", "W")))
+                    # Append the category id on the list
+                    labels_list.append(cat[1])
+
+            labels = torch.as_tensor([label for label in labels_list], dtype=torch.float32)
+            # Labels store the list of categories id and a list off all categories
+            labels_2d = Labels(
+                labels, labels_names=[cat[0] for cat in self.category], names=("N"), encoding="id"
+            )
+            all_masks = torch.cat(masks, dim=0)
+            frames["left"].append_segmentation(Mask(all_masks, labels=labels_2d, names=("N", "H", "W")))
+
+        return frames
+
+    # https://github.com/utiasSTARS/pykitti/tree/master
+    def read_calib_file(self, filepath):
+        """Read in a calibration file and parse into a dictionary."""
+        data = {}
+
+        with open(filepath, "r") as f:
+            for line in f.readlines():
+                if line == "\n":
+                    continue
+                key, value = line.split(":", 1)
+                # The only non-float values in these files are dates, which
+                # we don't care about anyway
+                try:
+                    data[key] = np.array([float(x) for x in value.split()])
+                except ValueError:
+                    pass
+
+        return data
+
+    def _load_calib(self, calib_filepath):
+        """Load and compute intrinsic and extrinsic calibration parameters."""
+        # We'll build the calibration parameters as a dictionary, then
+        # convert it to a namedtuple to prevent it from being modified later
+        data = {}
+
+        # Load the calibration file
+        filedata = self.read_calib_file(calib_filepath)
+
+        # Create 3x4 projection matrices
+        P_rect_00 = np.reshape(filedata["P0"], (3, 4))
+        P_rect_10 = np.reshape(filedata["P1"], (3, 4))
+        P_rect_20 = np.reshape(filedata["P2"], (3, 4))
+        P_rect_30 = np.reshape(filedata["P3"], (3, 4))
+
+        data["P_rect_00"] = P_rect_00
+        data["P_rect_10"] = P_rect_10
+        data["P_rect_20"] = P_rect_20
+        data["P_rect_30"] = P_rect_30
+
+        # Compute the rectified extrinsics from cam0 to camN
+        T0 = np.eye(4)
+        T0[0, 3] = P_rect_00[0, 3] / P_rect_00[0, 0]
+        T1 = np.eye(4)
+        T1[0, 3] = P_rect_10[0, 3] / P_rect_10[0, 0]
+        T2 = np.eye(4)
+        T2[0, 3] = P_rect_20[0, 3] / P_rect_20[0, 0]
+        T3 = np.eye(4)
+        T3[0, 3] = P_rect_30[0, 3] / P_rect_30[0, 0]
+
+        data["T_cam0_rect"] = T0
+        data["T_cam1_rect"] = T1
+        data["T_cam2_rect"] = T2
+        data["T_cam3_rect"] = T3
+
+        # Compute the camera intrinsics
+        data["K_cam0"] = P_rect_00[0:3, 0:3]
+        data["K_cam1"] = P_rect_10[0:3, 0:3]
+        data["K_cam2"] = P_rect_20[0:3, 0:3]
+        data["K_cam3"] = P_rect_30[0:3, 0:3]
+
+        return data
+
+
+if __name__ == "__main__":
+    from random import randint
+
+    dataset = KittiSemanticDataset()
+    obj = dataset.getitem(randint(0, len(dataset)))
+    print("final", obj["left"].shape, obj)
+    obj["left"].get_view().render()

--- a/alodataset/kitti_semantic.py
+++ b/alodataset/kitti_semantic.py
@@ -85,14 +85,13 @@ class KittiSemanticDataset(BaseDataset, SplitMixin):
             return color[:, :, 0] + 256 * color[:, :, 1] + 256 * 256 * color[:, :, 2]
         return int(color[0] + 256 * color[1] + 256 * 256 * color[2])
 
-    def getitem(self, idx):
+    def getitem(self, idx) -> Frame:
         item = self.items[idx]
 
         if self.sample:
             return BaseDataset.__getitem__(self, idx)
 
-        frames = {}
-        frames["left"] = Frame(item["left"])
+        frame = Frame(item["left"])
 
         if item["instance"] is not None:
             instance = cv2.imread(item["instance"], cv2.IMREAD_UNCHANGED)
@@ -116,13 +115,11 @@ class KittiSemanticDataset(BaseDataset, SplitMixin):
 
             labels = torch.as_tensor([label for label in labels_list], dtype=torch.float32)
             # Labels store the list of categories id and a list off all categories
-            labels_2d = Labels(
-                labels, labels_names=[cat[0] for cat in self.category], names=("N"), encoding="id"
-            )
+            labels_2d = Labels(labels, labels_names=[cat[0] for cat in self.category], names=("N"), encoding="id")
             all_masks = torch.cat(masks, dim=0)
-            frames["left"].append_segmentation(Mask(all_masks, labels=labels_2d, names=("N", "H", "W")))
+            frame.append_segmentation(Mask(all_masks, labels=labels_2d, names=("N", "H", "W")))
 
-        return frames
+        return frame
 
     # https://github.com/utiasSTARS/pykitti/tree/master
     def read_calib_file(self, filepath):
@@ -192,5 +189,5 @@ if __name__ == "__main__":
 
     dataset = KittiSemanticDataset()
     obj = dataset.getitem(randint(0, len(dataset)))
-    print("final", obj["left"].shape, obj)
-    obj["left"].get_view().render()
+    print("final", obj.shape, obj)
+    obj.get_view().render()

--- a/alodataset/kitti_semantic.py
+++ b/alodataset/kitti_semantic.py
@@ -19,7 +19,7 @@ class KittiSemanticDataset(BaseDataset, SplitMixin):
         super().__init__(name=name, **kwargs)
 
         if self.sample:
-            return
+            raise NotImplementedError("Sample mode is not implemented for KittiSemanticDataset")
 
         self.split_folder = os.path.join(self.dataset_dir, self.get_split_folder())
         left_img_folder = os.path.join(self.split_folder, "image_2")

--- a/alodataset/kitti_semantic.py
+++ b/alodataset/kitti_semantic.py
@@ -18,6 +18,9 @@ class KittiSemanticDataset(BaseDataset, SplitMixin):
     def __init__(self, name="kitti_semantic", **kwargs):
         super().__init__(name=name, **kwargs)
 
+        if self.sample:
+            return
+
         self.split_folder = os.path.join(self.dataset_dir, self.get_split_folder())
         left_img_folder = os.path.join(self.split_folder, "image_2")
         n_samples = len([file for file in os.listdir(left_img_folder)])
@@ -84,6 +87,9 @@ class KittiSemanticDataset(BaseDataset, SplitMixin):
 
     def getitem(self, idx):
         item = self.items[idx]
+
+        if self.sample:
+            return BaseDataset.__getitem__(self, idx)
 
         frames = {}
         frames["left"] = Frame(item["left"])

--- a/alodataset/kitti_split_dataset.py
+++ b/alodataset/kitti_split_dataset.py
@@ -1,0 +1,38 @@
+import torch
+import numpy as np
+from typing import Dict, List
+from aloscene import Frame, Mask
+from alodataset import Split, SplitMixin
+from alodataset.kitti_depth import KittiBaseDataset
+
+
+class KittiSplitDataset(KittiBaseDataset, SplitMixin):
+    SPLIT_FOLDERS = {Split.VAL: "val", Split.TRAIN: "train"}
+
+    def __init__(
+            self,
+            split=Split.TRAIN,
+            add_depth_mask: bool = True,
+            custom_drives: Dict[str, List[str]] = None,
+            main_folder: str = 'image_02',
+            name: str='kitti',
+            **kwargs
+    ):
+
+        self.split = split
+        self.add_depth_mask = add_depth_mask
+        super().__init__(
+            subsets=self.get_split_folder(),
+            name=name,
+            custom_drives=custom_drives,
+            main_folder=main_folder,
+            return_depth=True,
+            **kwargs)
+
+
+    def getitem(self, idx):
+        frame = super().getitem(idx)
+        if self.add_depth_mask:
+            mask = Mask((frame.depth.as_tensor() != 0).type(torch.float), names=frame.depth.names)
+            frame.depth.add_child("valid_mask", mask, align_dim=["B", "T"], mergeable=True)
+        return frame

--- a/alodataset/kitti_stereo_flow2012.py
+++ b/alodataset/kitti_stereo_flow2012.py
@@ -59,18 +59,18 @@ class KittiStereoFlow2012(BaseDataset, SplitMixin):
         img = cv2.imread(disp_path, cv2.IMREAD_UNCHANGED)
         disp = img / 256.0
         disp = torch.as_tensor(disp[None, ...], dtype=torch.float32)
-        valid_mask = disp > 0
-        mask = Mask(valid_mask, names=("C", "H", "W"))
+        mask = disp <= 0
+        mask = Mask(mask, names=("C", "H", "W"))
         disp = Disparity(disp, names=("C", "H", "W"), mask=mask, camera_side=camera_side).signed()
         return disp
 
     def load_flow(self, flow_path: str):
         img = cv2.imread(flow_path, cv2.IMREAD_UNCHANGED)
-        valid_mask = img[..., 0] == 1
+        mask = img[..., 0] == 0
         flow = (img - 2**15) / 64.0
         flow = torch.as_tensor(flow[..., 1:], dtype=torch.float32).permute(2, 0, 1)
-        valid_mask = valid_mask.reshape((1, flow.shape[1], flow.shape[2]))
-        mask = Mask(valid_mask, names=("C", "H", "W"))
+        mask = mask.reshape((1, flow.shape[1], flow.shape[2]))
+        mask = Mask(mask, names=("C", "H", "W"))
         flow = Flow(flow, names=("C", "H", "W"), mask=mask)
         return flow
 
@@ -257,4 +257,4 @@ if __name__ == "__main__":
     dataset = KittiStereoFlow2012(grayscale=True, sequence_start=9)
     obj = dataset.getitem(0)
     print(obj)
-    obj[9]["left"].get_view().render()
+    obj[10]["left"].get_view().render()

--- a/alodataset/kitti_stereo_flow2012.py
+++ b/alodataset/kitti_stereo_flow2012.py
@@ -36,7 +36,7 @@ class KittiStereoFlow2012(BaseDataset, SplitMixin):
         self.sequence_end = sequence_end
 
         if self.sample:
-            return
+            raise NotImplementedError("Sample mode is not implemented for KittiStereoFlow2012")
 
         assert sequence_start <= sequence_end, "sequence_start should be less than sequence_end"
 

--- a/alodataset/kitti_stereo_flow2012.py
+++ b/alodataset/kitti_stereo_flow2012.py
@@ -8,6 +8,8 @@ from alodataset import BaseDataset, Split, SplitMixin
 from aloscene import Frame, Disparity, Mask, Flow
 from aloscene.camera_calib import CameraIntrinsic, CameraExtrinsic
 
+from alodataset.utils.kitti import load_calib_cam_to_cam
+
 
 class KittiStereoFlow2012(BaseDataset, SplitMixin):
     SPLIT_FOLDERS = {Split.TRAIN: "training", Split.TEST: "testing"}
@@ -103,7 +105,7 @@ class KittiStereoFlow2012(BaseDataset, SplitMixin):
             return BaseDataset.__getitem__(self, idx)
 
         # Read the calibration file
-        calib = self._load_calib(os.path.join(self.split_folder, "calib", f"{idx:06d}.txt"))
+        calib = load_calib_cam_to_cam(os.path.join(self.split_folder, "calib", f"{idx:06d}.txt"))
 
         sequence: Dict[int, Dict[str, Frame]] = {}
 
@@ -113,16 +115,24 @@ class KittiStereoFlow2012(BaseDataset, SplitMixin):
                 os.path.join(self.split_folder, f"image_{0 if self.grayscale else 2}/{idx:06d}_{index:02d}.png")
             )
             sequence[index]["left"].baseline = 0.54
-            sequence[index]["left"].append_cam_extrinsic(calib["left_extrinsic"])
-            sequence[index]["left"].append_cam_intrinsic(calib["left_intrinsic"])
+            sequence[index]["left"].append_cam_extrinsic(
+                CameraExtrinsic(calib["T_cam0_rect"] if self.grayscale else calib["T_cam2_rect"])
+            )
+            sequence[index]["left"].append_cam_intrinsic(
+                CameraIntrinsic(np.c_[calib["K_cam0"] if self.grayscale else calib["K_cam2"], [0, 0, 0]])
+            )
 
             if "right" in self.load:
                 sequence[index]["right"] = Frame(
                     os.path.join(self.split_folder, f"image_{1 if self.grayscale else 3}/{idx:06d}_{index:02d}.png")
                 )
                 sequence[index]["right"].baseline = 0.54
-                sequence[index]["right"].append_cam_extrinsic(calib["right_extrinsic"])
-                sequence[index]["right"].append_cam_intrinsic(calib["right_intrinsic"])
+                sequence[index]["right"].append_cam_extrinsic(
+                    CameraExtrinsic(calib["T_cam1_rect"] if self.grayscale else calib["T_cam3_rect"])
+                )
+                sequence[index]["right"].append_cam_intrinsic(
+                    CameraIntrinsic(np.c_[calib["K_cam1"] if self.grayscale else calib["K_cam3"], [0, 0, 0]])
+                )
 
             # Frame at index 10 is the only one to have ground truth in dataset.
             if index == 10:
@@ -197,78 +207,10 @@ class KittiStereoFlow2012(BaseDataset, SplitMixin):
 
         return result
 
-    # https://github.com/utiasSTARS/pykitti/tree/master
-    def read_calib_file(self, filepath):
-        """Read in a calibration file and parse into a dictionary."""
-        data = {}
-
-        with open(filepath, "r") as f:
-            for line in f.readlines():
-                key, value = line.split(":", 1)
-                # The only non-float values in these files are dates, which
-                # we don't care about anyway
-                try:
-                    data[key] = np.array([float(x) for x in value.split()])
-                except ValueError:
-                    pass
-
-        return data
-
-    def _load_calib(self, calib_filepath):
-        """Load and compute intrinsic and extrinsic calibration parameters."""
-        # We'll build the calibration parameters as a dictionary, then
-        # convert it to a namedtuple to prevent it from being modified later
-        data = {}
-
-        # Load the calibration file
-        filedata = self.read_calib_file(calib_filepath)
-
-        # Create 3x4 projection matrices
-        P_rect_00 = np.reshape(filedata["P0"], (3, 4))
-        P_rect_10 = np.reshape(filedata["P1"], (3, 4))
-        P_rect_20 = np.reshape(filedata["P2"], (3, 4))
-        P_rect_30 = np.reshape(filedata["P3"], (3, 4))
-
-        data["P_rect_00"] = P_rect_00
-        data["P_rect_10"] = P_rect_10
-        data["P_rect_20"] = P_rect_20
-        data["P_rect_30"] = P_rect_30
-
-        # Compute the rectified extrinsics from cam0 to camN
-        T0 = np.eye(4)
-        T0[0, 3] = P_rect_00[0, 3] / P_rect_00[0, 0]
-        T1 = np.eye(4)
-        T1[0, 3] = P_rect_10[0, 3] / P_rect_10[0, 0]
-        T2 = np.eye(4)
-        T2[0, 3] = P_rect_20[0, 3] / P_rect_20[0, 0]
-        T3 = np.eye(4)
-        T3[0, 3] = P_rect_30[0, 3] / P_rect_30[0, 0]
-
-        data["T0"] = T0
-        data["T1"] = T1
-        data["T2"] = T2
-        data["T3"] = T3
-
-        # Compute the camera intrinsics
-        data["K_cam0"] = P_rect_00[0:3, 0:3]
-        data["K_cam1"] = P_rect_10[0:3, 0:3]
-        data["K_cam2"] = P_rect_20[0:3, 0:3]
-        data["K_cam3"] = P_rect_30[0:3, 0:3]
-
-        # Return only the parameters we care.
-        result = {
-            "left_intrinsic": CameraIntrinsic(np.c_[data["K_cam0"] if self.grayscale else data["K_cam2"], [0, 0, 0]]),
-            "right_intrinsic": CameraIntrinsic(np.c_[data["K_cam1"] if self.grayscale else data["K_cam3"], [0, 0, 0]]),
-            "left_extrinsic": CameraExtrinsic(data["T0"] if self.grayscale else data["T2"]),
-            "right_extrinsic": CameraExtrinsic(data["T1"] if self.grayscale else data["T3"]),
-        }
-        return result
-
 
 if __name__ == "__main__":
     from random import randint
 
     dataset = KittiStereoFlow2012(grayscale=True, sequence_start=8)
     obj = dataset.getitem(randint(0, len(dataset)))
-    print(obj)
     obj["left"].get_view().render()

--- a/alodataset/kitti_stereo_flow2012.py
+++ b/alodataset/kitti_stereo_flow2012.py
@@ -83,7 +83,7 @@ class KittiStereoFlow2012(BaseDataset, SplitMixin):
         disp_refl = Disparity(disp_refl, names=("C", "H", "W"), camera_side=camera_side, mask=mask).signed()
         return disp_refl
 
-    def getitem(self, idx: int) -> Dict[int, Dict[str, Frame]]:
+    def getitem(self, idx: int) -> Dict[str, Frame]:
         """
         Loads a sequence of frames from the dataset.
 

--- a/alodataset/kitti_stereo_flow2012.py
+++ b/alodataset/kitti_stereo_flow2012.py
@@ -1,0 +1,182 @@
+import os
+import cv2
+import torch
+import numpy as np
+from typing import Dict
+
+from alodataset import BaseDataset, Split, SplitMixin
+from aloscene import Frame, Disparity, Mask, Flow
+from aloscene.camera_calib import CameraIntrinsic, CameraExtrinsic
+
+
+class KittiStereoFlow2012(BaseDataset, SplitMixin):
+    SPLIT_FOLDERS = {Split.TRAIN: "training", Split.TEST: "testing"}
+
+    def __init__(
+        self,
+        name="kitti_stereo2012",
+        grayscale=False,
+        sequence_start=10,
+        sequence_end=11,
+        load: list = [
+            "disp_noc",
+            "disp_occ",
+            "disp_refl_noc",
+            "disp_refl_occ",
+            "flow_occ",
+            "flow_noc",
+            "intrinsic",
+        ],
+        **kwargs,
+    ):
+        super().__init__(name=name, **kwargs)
+        self.grayscale = grayscale
+        self.load = load
+        self.sequence_start = sequence_start
+        self.sequence_end = sequence_end
+
+        if self.sample:
+            return
+
+        assert sequence_start <= sequence_end, "sequence_start should be less than sequence_end"
+
+        if "disp_noc" in load or "disp_occ" in load or "disp_refl_noc" in load or "disp_refl_occ" in load:
+            assert sequence_start <= 11 and sequence_end >= 10, "Disparity is not available for this frame range"
+        if "flow_occ" in load or "flow_noc" in load:
+            assert sequence_start <= 10 and sequence_end >= 10, "Flow is not available for this frame range"
+
+        self.split_folder = os.path.join(self.dataset_dir, self.get_split_folder())
+        left_img_folder = os.path.join(self.split_folder, "image_0")
+        self.len = len([f for f in os.listdir(left_img_folder) if f.endswith("_10.png")])
+
+    def __len__(self):
+        if self.sample:
+            return len(self.items)
+        return self.len
+
+    def load_disp(self, disp_path: str):
+        img = cv2.imread(disp_path, cv2.IMREAD_UNCHANGED)
+        disp = img / 256.0
+        disp = torch.as_tensor(disp[None, ...], dtype=torch.float32)
+        valid_mask = disp > 0
+        mask = Mask(valid_mask, names=("C", "H", "W"))
+        disp = Disparity(disp, names=("C", "H", "W"), mask=mask)
+        return disp
+
+    def load_flow(self, flow_path: str):
+        img = cv2.imread(flow_path, cv2.IMREAD_UNCHANGED)
+        valid_mask = img[..., 0] == 1
+        flow = (img - 2**15) / 64.0
+        flow = torch.as_tensor(flow[..., 1:], dtype=torch.float32).permute(2, 0, 1)
+        valid_mask = valid_mask.reshape((1, flow.shape[1], flow.shape[2]))
+        mask = Mask(valid_mask, names=("C", "H", "W"))
+        flow = Flow(flow, names=("C", "H", "W"), mask=mask)
+        return flow
+
+    def load_disp_refl(self, disp_refl_path: str):
+        img = cv2.imread(disp_refl_path, cv2.IMREAD_UNCHANGED).astype(bool)
+        disp_refl = torch.as_tensor(img[None, ...], dtype=torch.float32)
+        disp_refl = Disparity(disp_refl, names=("C", "H", "W"))
+        return disp_refl
+
+    @staticmethod
+    def _get_cam_intrinsic(size):
+        return CameraIntrinsic(focal_length=721.0, plane_size=size)
+
+    @staticmethod
+    def _fake_extrinsinc():
+        x = torch.eye(4, dtype=torch.float32)
+        return CameraExtrinsic(x)
+
+    def getitem(self, idx: int):
+        """Function for compatibility
+
+        Parameters
+        ----------
+        idx : int
+            Index of the item
+
+        Returns
+        -------
+        """
+        if self.sample:
+            return BaseDataset.__getitem__(self, idx)
+        return self.getsequence(idx)
+
+    def getsequence(self, idx: int) -> Dict[int, Dict[str, Frame]]:
+        """
+        Loads a sequence of frames from the dataset.
+
+        Parameters
+        ----------
+        idx : int
+            Index of the sequence.
+
+        Returns
+        -------
+        Dict[int, Dict[str, Frame]]
+            Dictionary of index beetween sequance_start and sequance_end.\n
+            Each index is a dictionary of frames ("left" and maybe "right").
+        """
+
+        # Read the calibration file
+        calib = None
+        if "intrinsic" in self.load:
+            with open(os.path.join(self.split_folder, "calib", f"{idx:06d}.txt")) as f:
+                calib = f.readlines()
+
+        sequence: Dict[int, Dict[str, Frame]] = {}
+
+        for index in range(self.sequence_end, self.sequence_start - 1, -1):
+            sequence[index] = {}
+            sequence[index]["left"] = Frame(
+                os.path.join(self.split_folder, f"image_{0 if self.grayscale else 2}/{idx:06d}_{index:02d}.png")
+            )
+            sequence[index]["left"].baseline = 0.54
+            sequence[index]["left"].append_cam_extrinsic(self._fake_extrinsinc())
+            if calib is not None:
+                sequence[index]["left"].append_cam_intrinsic(
+                    CameraIntrinsic(np.array([float(x) for x in calib[0].split()[1:]]).reshape(3, 4))
+                )
+
+            if "right" in self.load:
+                sequence[index]["right"] = Frame(
+                    os.path.join(self.split_folder, f"image_{1 if self.grayscale else 3}/{idx:06d}_{index:02d}.png")
+                )
+                sequence[index]["right"].baseline = 0.54
+                sequence[index]["right"].append_cam_extrinsic(self._fake_extrinsinc())
+                if calib is not None:
+                    sequence[index]["right"].append_cam_intrinsic(
+                        CameraIntrinsic(np.array([float(x) for x in calib[1].split()[1:]]).reshape(3, 4))
+                    )
+
+            # Frame at index 10 is the only one to have ground truth in dataset.
+            if index == 10:
+                if "disp_noc" in self.load:
+                    sequence[10]["left"].append_disparity(
+                        self.load_disp(os.path.join(self.split_folder, f"disp_noc/{idx:06d}_10.png")), "disp_noc"
+                    )
+                if "disp_occ" in self.load:
+                    sequence[10]["left"].append_disparity(
+                        self.load_disp(os.path.join(self.split_folder, f"disp_occ/{idx:06d}_10.png")), "disp_occ"
+                    )
+                if "disp_refl_noc" in self.load:
+                    sequence[10]["left"].append_disparity(
+                        self.load_disp_refl(os.path.join(self.split_folder, f"disp_refl_noc/{idx:06d}_10.png")),
+                        "disp_refl_noc",
+                    )
+                if "disp_refl_occ" in self.load:
+                    sequence[10]["left"].append_disparity(
+                        self.load_disp_refl(os.path.join(self.split_folder, f"disp_refl_occ/{idx:06d}_10.png")),
+                        "disp_refl_occ",
+                    )
+                if "flow_occ" in self.load:
+                    sequence[10]["left"].append_flow(
+                        self.load_flow(os.path.join(self.split_folder, f"flow_occ/{idx:06d}_10.png")), "flow_occ"
+                    )
+                if "flow_noc" in self.load:
+                    sequence[10]["left"].append_flow(
+                        self.load_flow(os.path.join(self.split_folder, f"flow_noc/{idx:06d}_10.png")), "flow_noc"
+                    )
+
+        return sequence

--- a/alodataset/kitti_stereo_flow2012.py
+++ b/alodataset/kitti_stereo_flow2012.py
@@ -167,6 +167,20 @@ class KittiStereoFlow2012(BaseDataset, SplitMixin):
                     sequence[10]["left"].append_flow(
                         self.load_flow(os.path.join(self.split_folder, f"flow_noc/{idx:06d}_10.png")), "flow_noc"
                     )
+            else:
+                dummy_size = (2, sequence[index]["left"].HW[0], sequence[index]["left"].HW[1])
+                if "disp_noc" in self.load:
+                    sequence[index]["left"].append_disparity(Disparity.dummy(dummy_size), "disp_noc")
+                if "disp_occ" in self.load:
+                    sequence[index]["left"].append_disparity(Disparity.dummy(dummy_size), "disp_occ")
+                if "disp_refl_noc" in self.load:
+                    sequence[index]["left"].append_disparity(Disparity.dummy(dummy_size), "disp_refl_noc")
+                if "disp_refl_occ" in self.load:
+                    sequence[index]["left"].append_disparity(Disparity.dummy(dummy_size), "disp_refl_occ")
+                if "flow_occ" in self.load:
+                    sequence[index]["left"].append_flow(Flow.dummy(dummy_size), "flow_occ")
+                if "flow_noc" in self.load:
+                    sequence[index]["left"].append_flow(Flow.dummy(dummy_size), "flow_noc")
 
         return sequence
 
@@ -239,5 +253,7 @@ class KittiStereoFlow2012(BaseDataset, SplitMixin):
 
 
 if __name__ == "__main__":
-    dataset = KittiStereoFlow2012(grayscale=True)
-    print(dataset.getitem(0))
+    dataset = KittiStereoFlow2012(grayscale=True, sequence_start=9)
+    obj = dataset.getitem(0)
+    print(obj)
+    obj[9]["left"].get_view().render()

--- a/alodataset/kitti_stereo_flow2012.py
+++ b/alodataset/kitti_stereo_flow2012.py
@@ -83,22 +83,7 @@ class KittiStereoFlow2012(BaseDataset, SplitMixin):
         disp_refl = Disparity(disp_refl, names=("C", "H", "W"), camera_side=camera_side, mask=mask).signed()
         return disp_refl
 
-    def getitem(self, idx: int):
-        """Function for compatibility
-
-        Parameters
-        ----------
-        idx : int
-            Index of the item
-
-        Returns
-        -------
-        """
-        if self.sample:
-            return BaseDataset.__getitem__(self, idx)
-        return self.getsequence(idx)
-
-    def getsequence(self, idx: int) -> Dict[int, Dict[str, Frame]]:
+    def getitem(self, idx: int) -> Dict[int, Dict[str, Frame]]:
         """
         Loads a sequence of frames from the dataset.
 
@@ -113,6 +98,9 @@ class KittiStereoFlow2012(BaseDataset, SplitMixin):
             Dictionary of index beetween sequance_start and sequance_end.\n
             Each index is a dictionary of frames ("left" and maybe "right").
         """
+
+        if self.sample:
+            return BaseDataset.__getitem__(self, idx)
 
         # Read the calibration file
         calib = self._load_calib(os.path.join(self.split_folder, "calib", f"{idx:06d}.txt"))

--- a/alodataset/kitti_stereo_flow2012.py
+++ b/alodataset/kitti_stereo_flow2012.py
@@ -169,18 +169,19 @@ class KittiStereoFlow2012(BaseDataset, SplitMixin):
                     )
             else:
                 dummy_size = (2, sequence[index]["left"].HW[0], sequence[index]["left"].HW[1])
+                dummy_names = ("C", "H", "W")
                 if "disp_noc" in self.load:
-                    sequence[index]["left"].append_disparity(Disparity.dummy(dummy_size), "disp_noc")
+                    sequence[index]["left"].append_disparity(Disparity.dummy(dummy_size, dummy_names), "disp_noc")
                 if "disp_occ" in self.load:
-                    sequence[index]["left"].append_disparity(Disparity.dummy(dummy_size), "disp_occ")
+                    sequence[index]["left"].append_disparity(Disparity.dummy(dummy_size, dummy_names), "disp_occ")
                 if "disp_refl_noc" in self.load:
-                    sequence[index]["left"].append_disparity(Disparity.dummy(dummy_size), "disp_refl_noc")
+                    sequence[index]["left"].append_disparity(Disparity.dummy(dummy_size, dummy_names), "disp_refl_noc")
                 if "disp_refl_occ" in self.load:
-                    sequence[index]["left"].append_disparity(Disparity.dummy(dummy_size), "disp_refl_occ")
+                    sequence[index]["left"].append_disparity(Disparity.dummy(dummy_size, dummy_names), "disp_refl_occ")
                 if "flow_occ" in self.load:
-                    sequence[index]["left"].append_flow(Flow.dummy(dummy_size), "flow_occ")
+                    sequence[index]["left"].append_flow(Flow.dummy(dummy_size, dummy_names), "flow_occ")
                 if "flow_noc" in self.load:
-                    sequence[index]["left"].append_flow(Flow.dummy(dummy_size), "flow_noc")
+                    sequence[index]["left"].append_flow(Flow.dummy(dummy_size, dummy_names), "flow_noc")
 
         return sequence
 

--- a/alodataset/kitti_stereo_flow_sflow2015.py
+++ b/alodataset/kitti_stereo_flow_sflow2015.py
@@ -138,7 +138,7 @@ class KittiStereoFlowSFlow2015(BaseDataset, SplitMixin):
         scene_flow.nan_to_num_(0, 0, 0)
         return scene_flow
 
-    def getitem(self, idx) -> Dict[int, Dict[str, Frame]]:
+    def getitem(self, idx) -> Dict[str, Frame]:
         """
         Load a sequence of frames from the dataset.
 

--- a/alodataset/kitti_stereo_flow_sflow2015.py
+++ b/alodataset/kitti_stereo_flow_sflow2015.py
@@ -304,23 +304,12 @@ class KittiStereoFlowSFlow2015(BaseDataset, SplitMixin):
         return result
 
     def _load_calib(self, path, idx):
-        """Load and compute intrinsic and extrinsic calibration parameters."""
-        # We'll build the calibration parameters as a dictionary, then
-        # convert it to a namedtuple to prevent it from being modified later
-        data = {}
-
-        # Load the rigid transformation from IMU to velodyne
-        data["T_velo_imu"] = self._load_calib_rigid(os.path.join(path, "calib_imu_to_velo", f"{idx:06d}.txt"))
-
-        # Load the camera intrinsics and extrinsics
-        data.update(
-            load_calib_cam_to_cam(
-                os.path.join(path, "calib_cam_to_cam", f"{idx:06d}.txt"),
-                os.path.join(path, "calib_velo_to_cam", f"{idx:06d}.txt"),
-            )
+        data = load_calib_cam_to_cam(
+            os.path.join(path, "calib_cam_to_cam", f"{idx:06d}.txt"),
+            os.path.join(path, "calib_velo_to_cam", f"{idx:06d}.txt"),
         )
 
-        # Return the parameters we want only
+        # Return only the parameters we are interested in.
         result = {
             "baseline": data["b_gray"] if self.grayscale else data["b_rgb"],
             "left_intrinsic": CameraIntrinsic(np.c_[data["K_cam0"] if self.grayscale else data["K_cam2"], [0, 0, 0]]),

--- a/alodataset/kitti_stereo_flow_sflow2015.py
+++ b/alodataset/kitti_stereo_flow_sflow2015.py
@@ -242,16 +242,18 @@ class KittiStereoFlowSFlow2015(BaseDataset, SplitMixin):
             else:
                 dummy_size = (2, sequence[10]["left"].H, sequence[10]["left"].W)
                 if "disp_noc" in self.load:
-                    sequence[index]["left"].append_disparity(Disparity.dummy(dummy_size), "disp_noc")
+                    sequence[index]["left"].append_disparity(Disparity.dummy(dummy_size, ("C", "H", "W")), "disp_noc")
                 if "disp_occ" in self.load:
-                    sequence[index]["left"].append_disparity(Disparity.dummy(dummy_size), "disp_occ")
+                    sequence[index]["left"].append_disparity(Disparity.dummy(dummy_size, ("C", "H", "W")), "disp_occ")
                 if "flow_occ" in self.load:
-                    sequence[index]["left"].append_flow(Flow.dummy(dummy_size), "flow_occ")
+                    sequence[index]["left"].append_flow(Flow.dummy(dummy_size, ("C", "H", "W")), "flow_occ")
                 if "flow_noc" in self.load:
-                    sequence[index]["left"].append_flow(Flow.dummy(dummy_size), "flow_noc")
+                    sequence[index]["left"].append_flow(Flow.dummy(dummy_size, ("C", "H", "W")), "flow_noc")
                 if "scene_flow" in self.load:
                     scene_flow_size = (3, sequence[10]["left"].H, sequence[10]["left"].W)
-                    sequence[index]["left"].append_scene_flow(SceneFlow.dummy(scene_flow_size), "scene_flow")
+                    sequence[index]["left"].append_scene_flow(
+                        SceneFlow.dummy(scene_flow_size, ("C", "H", "W")), "scene_flow"
+                    )
 
         return sequence
 
@@ -391,9 +393,10 @@ class KittiStereoFlowSFlow2015(BaseDataset, SplitMixin):
 
 
 if __name__ == "__main__":
-    dataset = KittiStereoFlowSFlow2015(sequence_start=9)
+    dataset = KittiStereoFlowSFlow2015(sequence_start=10)
     obj = dataset.getitem(0)
     print(obj)
+    obj[10]["left"].get_view().render()
     # obj[10]["left"].cam_extrinsic = obj[10]["left"].cam_extrinsic + 8
     # print(obj[11]["left"].cam_extrinsic)
     # obj[10]["left"].get_view().render()

--- a/alodataset/kitti_stereo_flow_sflow2015.py
+++ b/alodataset/kitti_stereo_flow_sflow2015.py
@@ -17,6 +17,7 @@ class KittiStereoFlowSFlow2015(BaseDataset, SplitMixin):
         name="kitti_stereo2015",
         sequence_start=10,
         sequence_end=11,
+        grayscale=True,
         load: list = [
             "right_frame",
             "disp_noc",
@@ -31,6 +32,7 @@ class KittiStereoFlowSFlow2015(BaseDataset, SplitMixin):
         super().__init__(name=name, **kwargs)
         self.sequence_start = sequence_start
         self.sequence_end = sequence_end
+        self.grayscale = grayscale
         self.load = load
 
         if self.sample:
@@ -190,21 +192,21 @@ class KittiStereoFlowSFlow2015(BaseDataset, SplitMixin):
             Each index is a dictionary of frames ("left" and maybe "right").
         """
         sequence: Dict[int, Dict[str, Frame]] = {}
+        calib = self._load_calib(self.split_folder, idx)
 
         # We need to load the sequance from the last to the first frame because we need information from the previous
         # frame to compute the scene flow.
         for index in range(self.sequence_end, self.sequence_start - 1, -1):
             sequence[index] = {}
             sequence[index]["left"] = Frame(os.path.join(self.split_folder, f"image_2/{idx:06d}_{index:02d}.png"))
-            size = sequence[index]["left"].HW
-            sequence[index]["left"].baseline = 0.54
-            sequence[index]["left"].append_cam_intrinsic(self._get_cam_intrinsic(size))
-            sequence[index]["left"].append_cam_extrinsic(self.extrinsic(idx))
+            sequence[index]["left"].baseline = calib["baseline"]
+            sequence[index]["left"].append_cam_intrinsic(calib["left_intrinsic"])
+            sequence[index]["left"].append_cam_extrinsic(calib["left_extrinsic"])
             if "right" in self.load:
                 sequence[index]["right"] = Frame(os.path.join(self.split_folder, f"image_3/{idx:06d}_{index:02d}.png"))
-                sequence[index]["right"].baseline = 0.54
-                sequence[index]["right"].append_cam_intrinsic(self._get_cam_intrinsic(size))
-                sequence[index]["right"].append_cam_extrinsic(self.extrinsic(idx))
+                sequence[index]["right"].baseline = ["baseline"]
+                sequence[index]["right"].append_cam_intrinsic(calib["right_intrinsic"])
+                sequence[index]["right"].append_cam_extrinsic(calib["right_extrinsic"])
 
             # Frames at index 10 and 11 are the only one who have ground truth in dataset.
             if index == 11:
@@ -236,11 +238,148 @@ class KittiStereoFlowSFlow2015(BaseDataset, SplitMixin):
                 if "scene_flow" in self.load:
                     # The scene flow cannot be added currently because of a bug in his representation.
                     scene_flow = self.scene_flow_from_disp(sequence[10]["left"], sequence[11]["left"])
-                    # sequence[10]["left"].append_scene_flow(scene_flow)
+                    sequence[10]["left"].append_scene_flow(scene_flow)
                 if "obj_map" in self.load:
-                    for vehicule in self.load_obj_map(
-                        os.path.join(self.split_folder, f"obj_map/{idx:06d}_10.png")
-                    ):
+                    for vehicule in self.load_obj_map(os.path.join(self.split_folder, f"obj_map/{idx:06d}_10.png")):
                         sequence[10]["left"].append_mask(vehicule[1], str(vehicule[0]))
 
         return sequence
+
+    # https://github.com/utiasSTARS/pykitti/tree/master
+    def read_calib_file(self, filepath):
+        """Read in a calibration file and parse into a dictionary."""
+        data = {}
+
+        with open(filepath, "r") as f:
+            for line in f.readlines():
+                key, value = line.split(":", 1)
+                # The only non-float values in these files are dates, which
+                # we don't care about anyway
+                try:
+                    data[key] = np.array([float(x) for x in value.split()])
+                except ValueError:
+                    pass
+
+        return data
+
+    def transform_from_rot_trans(self, R, t):
+        """Transforation matrix from rotation matrix and translation vector."""
+        R = R.reshape(3, 3)
+        t = t.reshape(3, 1)
+        return np.vstack((np.hstack([R, t]), [0, 0, 0, 1]))
+
+    def _load_calib_rigid(self, filepath):
+        """Read a rigid transform calibration file as a numpy.array."""
+        data = self.read_calib_file(filepath)
+        return self.transform_from_rot_trans(data["R"], data["T"])
+
+    def _load_calib_cam_to_cam(self, velo_to_cam_file, cam_to_cam_filepath):
+        # We'll return the camera calibration as a dictionary
+        data = {}
+
+        # Load the rigid transformation from velodyne coordinates
+        # to unrectified cam0 coordinates
+        T_cam0unrect_velo = self._load_calib_rigid(velo_to_cam_file)
+        data["T_cam0_velo_unrect"] = T_cam0unrect_velo
+
+        # Load and parse the cam-to-cam calibration data
+        filedata = self.read_calib_file(cam_to_cam_filepath)
+
+        # Create 3x4 projection matrices
+        P_rect_00 = np.reshape(filedata["P_rect_00"], (3, 4))
+        P_rect_10 = np.reshape(filedata["P_rect_01"], (3, 4))
+        P_rect_20 = np.reshape(filedata["P_rect_02"], (3, 4))
+        P_rect_30 = np.reshape(filedata["P_rect_03"], (3, 4))
+
+        data["P_rect_00"] = P_rect_00
+        data["P_rect_10"] = P_rect_10
+        data["P_rect_20"] = P_rect_20
+        data["P_rect_30"] = P_rect_30
+
+        # Create 4x4 matrices from the rectifying rotation matrices
+        R_rect_00 = np.eye(4)
+        R_rect_00[0:3, 0:3] = np.reshape(filedata["R_rect_00"], (3, 3))
+        R_rect_10 = np.eye(4)
+        R_rect_10[0:3, 0:3] = np.reshape(filedata["R_rect_01"], (3, 3))
+        R_rect_20 = np.eye(4)
+        R_rect_20[0:3, 0:3] = np.reshape(filedata["R_rect_02"], (3, 3))
+        R_rect_30 = np.eye(4)
+        R_rect_30[0:3, 0:3] = np.reshape(filedata["R_rect_03"], (3, 3))
+
+        data["R_rect_00"] = R_rect_00
+        data["R_rect_10"] = R_rect_10
+        data["R_rect_20"] = R_rect_20
+        data["R_rect_30"] = R_rect_30
+
+        # Compute the rectified extrinsics from cam0 to camN
+        T0 = np.eye(4)
+        T0[0, 3] = P_rect_00[0, 3] / P_rect_00[0, 0]
+        T1 = np.eye(4)
+        T1[0, 3] = P_rect_10[0, 3] / P_rect_10[0, 0]
+        T2 = np.eye(4)
+        T2[0, 3] = P_rect_20[0, 3] / P_rect_20[0, 0]
+        T3 = np.eye(4)
+        T3[0, 3] = P_rect_30[0, 3] / P_rect_30[0, 0]
+
+        data["T_cam0_rect"] = T0
+        data["T_cam1_rect"] = T1
+        data["T_cam2_rect"] = T2
+        data["T_cam3_rect"] = T3
+
+        # Compute the velodyne to rectified camera coordinate transforms
+        data["T_cam0_velo"] = T0.dot(R_rect_00.dot(T_cam0unrect_velo))
+        data["T_cam1_velo"] = T1.dot(R_rect_00.dot(T_cam0unrect_velo))
+        data["T_cam2_velo"] = T2.dot(R_rect_00.dot(T_cam0unrect_velo))
+        data["T_cam3_velo"] = T3.dot(R_rect_00.dot(T_cam0unrect_velo))
+
+        # Compute the camera intrinsics
+        data["K_cam0"] = P_rect_00[0:3, 0:3]
+        data["K_cam1"] = P_rect_10[0:3, 0:3]
+        data["K_cam2"] = P_rect_20[0:3, 0:3]
+        data["K_cam3"] = P_rect_30[0:3, 0:3]
+
+        # Compute the stereo baselines in meters by projecting the origin of
+        # each camera frame into the velodyne frame and computing the distances
+        # between them
+        p_cam = np.array([0, 0, 0, 1])
+        p_velo0 = np.linalg.inv(data["T_cam0_velo"]).dot(p_cam)
+        p_velo1 = np.linalg.inv(data["T_cam1_velo"]).dot(p_cam)
+        p_velo2 = np.linalg.inv(data["T_cam2_velo"]).dot(p_cam)
+        p_velo3 = np.linalg.inv(data["T_cam3_velo"]).dot(p_cam)
+
+        data["b_gray"] = np.linalg.norm(p_velo1 - p_velo0)  # gray baseline
+        data["b_rgb"] = np.linalg.norm(p_velo3 - p_velo2)  # rgb baseline
+
+        return data
+
+    def _load_calib(self, path, idx):
+        """Load and compute intrinsic and extrinsic calibration parameters."""
+        # We'll build the calibration parameters as a dictionary, then
+        # convert it to a namedtuple to prevent it from being modified later
+        data = {}
+
+        # Load the rigid transformation from IMU to velodyne
+        data["T_velo_imu"] = self._load_calib_rigid(os.path.join(path, "calib_imu_to_velo", f"{idx:06d}.txt"))
+
+        # Load the camera intrinsics and extrinsics
+        data.update(
+            self._load_calib_cam_to_cam(
+                os.path.join(path, "calib_velo_to_cam", f"{idx:06d}.txt"),
+                os.path.join(path, "calib_cam_to_cam", f"{idx:06d}.txt"),
+            )
+        )
+
+        # Return the parameters we want only
+        result = {
+            "baseline": data["b_gray"] if self.grayscale else data["b_rgb"],
+            "left_intrinsic": CameraIntrinsic(np.c_[data["K_cam0"] if self.grayscale else data["K_cam2"], [0, 0, 0]]),
+            "right_intrinsic": CameraIntrinsic(np.c_[data["K_cam1"] if self.grayscale else data["K_cam3"], [0, 0, 0]]),
+            "left_extrinsic": CameraExtrinsic(data["T_cam0_rect"] if self.grayscale else data["T_cam2_rect"]),
+            "right_extrinsic": CameraExtrinsic(data["T_cam1_rect"] if self.grayscale else data["T_cam3_rect"]),
+        }
+        return result
+
+
+if __name__ == "__main__":
+    dataset = KittiStereoFlowSFlow2015()
+    print(dataset.getitem(0))

--- a/alodataset/kitti_stereo_flow_sflow2015.py
+++ b/alodataset/kitti_stereo_flow_sflow2015.py
@@ -8,6 +8,8 @@ from alodataset import BaseDataset, Split, SplitMixin
 from aloscene import Frame, Disparity, Mask, Flow, SceneFlow
 from aloscene.camera_calib import CameraIntrinsic, CameraExtrinsic
 
+from alodataset.utils.kitti import load_calib_cam_to_cam
+
 
 class KittiStereoFlowSFlow2015(BaseDataset, SplitMixin):
     SPLIT_FOLDERS = {Split.TRAIN: "training", Split.TEST: "testing"}
@@ -301,113 +303,6 @@ class KittiStereoFlowSFlow2015(BaseDataset, SplitMixin):
 
         return result
 
-    # https://github.com/utiasSTARS/pykitti/tree/master
-    def read_calib_file(self, filepath):
-        """Read in a calibration file and parse into a dictionary."""
-        data = {}
-
-        with open(filepath, "r") as f:
-            for line in f.readlines():
-                key, value = line.split(":", 1)
-                # The only non-float values in these files are dates, which
-                # we don't care about anyway
-                try:
-                    data[key] = np.array([float(x) for x in value.split()])
-                except ValueError:
-                    pass
-
-        return data
-
-    def transform_from_rot_trans(self, R, t):
-        """Transforation matrix from rotation matrix and translation vector."""
-        R = R.reshape(3, 3)
-        t = t.reshape(3, 1)
-        return np.vstack((np.hstack([R, t]), [0, 0, 0, 1]))
-
-    def _load_calib_rigid(self, filepath):
-        """Read a rigid transform calibration file as a numpy.array."""
-        data = self.read_calib_file(filepath)
-        return self.transform_from_rot_trans(data["R"], data["T"])
-
-    def _load_calib_cam_to_cam(self, velo_to_cam_file, cam_to_cam_filepath):
-        # We'll return the camera calibration as a dictionary
-        data = {}
-
-        # Load the rigid transformation from velodyne coordinates
-        # to unrectified cam0 coordinates
-        T_cam0unrect_velo = self._load_calib_rigid(velo_to_cam_file)
-        data["T_cam0_velo_unrect"] = T_cam0unrect_velo
-
-        # Load and parse the cam-to-cam calibration data
-        filedata = self.read_calib_file(cam_to_cam_filepath)
-
-        # Create 3x4 projection matrices
-        P_rect_00 = np.reshape(filedata["P_rect_00"], (3, 4))
-        P_rect_10 = np.reshape(filedata["P_rect_01"], (3, 4))
-        P_rect_20 = np.reshape(filedata["P_rect_02"], (3, 4))
-        P_rect_30 = np.reshape(filedata["P_rect_03"], (3, 4))
-
-        data["P_rect_00"] = P_rect_00
-        data["P_rect_10"] = P_rect_10
-        data["P_rect_20"] = P_rect_20
-        data["P_rect_30"] = P_rect_30
-
-        # Create 4x4 matrices from the rectifying rotation matrices
-        R_rect_00 = np.eye(4)
-        R_rect_00[0:3, 0:3] = np.reshape(filedata["R_rect_00"], (3, 3))
-        R_rect_10 = np.eye(4)
-        R_rect_10[0:3, 0:3] = np.reshape(filedata["R_rect_01"], (3, 3))
-        R_rect_20 = np.eye(4)
-        R_rect_20[0:3, 0:3] = np.reshape(filedata["R_rect_02"], (3, 3))
-        R_rect_30 = np.eye(4)
-        R_rect_30[0:3, 0:3] = np.reshape(filedata["R_rect_03"], (3, 3))
-
-        data["R_rect_00"] = R_rect_00
-        data["R_rect_10"] = R_rect_10
-        data["R_rect_20"] = R_rect_20
-        data["R_rect_30"] = R_rect_30
-
-        # Compute the rectified extrinsics from cam0 to camN
-        T0 = np.eye(4)
-        T0[0, 3] = P_rect_00[0, 3] / P_rect_00[0, 0]
-        T1 = np.eye(4)
-        T1[0, 3] = P_rect_10[0, 3] / P_rect_10[0, 0]
-        T2 = np.eye(4)
-        T2[0, 3] = P_rect_20[0, 3] / P_rect_20[0, 0]
-        T3 = np.eye(4)
-        T3[0, 3] = P_rect_30[0, 3] / P_rect_30[0, 0]
-
-        data["T_cam0_rect"] = T0
-        data["T_cam1_rect"] = T1
-        data["T_cam2_rect"] = T2
-        data["T_cam3_rect"] = T3
-
-        # Compute the velodyne to rectified camera coordinate transforms
-        data["T_cam0_velo"] = T0.dot(R_rect_00.dot(T_cam0unrect_velo))
-        data["T_cam1_velo"] = T1.dot(R_rect_00.dot(T_cam0unrect_velo))
-        data["T_cam2_velo"] = T2.dot(R_rect_00.dot(T_cam0unrect_velo))
-        data["T_cam3_velo"] = T3.dot(R_rect_00.dot(T_cam0unrect_velo))
-
-        # Compute the camera intrinsics
-        data["K_cam0"] = P_rect_00[0:3, 0:3]
-        data["K_cam1"] = P_rect_10[0:3, 0:3]
-        data["K_cam2"] = P_rect_20[0:3, 0:3]
-        data["K_cam3"] = P_rect_30[0:3, 0:3]
-
-        # Compute the stereo baselines in meters by projecting the origin of
-        # each camera frame into the velodyne frame and computing the distances
-        # between them
-        p_cam = np.array([0, 0, 0, 1])
-        p_velo0 = np.linalg.inv(data["T_cam0_velo"]).dot(p_cam)
-        p_velo1 = np.linalg.inv(data["T_cam1_velo"]).dot(p_cam)
-        p_velo2 = np.linalg.inv(data["T_cam2_velo"]).dot(p_cam)
-        p_velo3 = np.linalg.inv(data["T_cam3_velo"]).dot(p_cam)
-
-        data["b_gray"] = np.linalg.norm(p_velo1 - p_velo0)  # gray baseline
-        data["b_rgb"] = np.linalg.norm(p_velo3 - p_velo2)  # rgb baseline
-
-        return data
-
     def _load_calib(self, path, idx):
         """Load and compute intrinsic and extrinsic calibration parameters."""
         # We'll build the calibration parameters as a dictionary, then
@@ -419,9 +314,9 @@ class KittiStereoFlowSFlow2015(BaseDataset, SplitMixin):
 
         # Load the camera intrinsics and extrinsics
         data.update(
-            self._load_calib_cam_to_cam(
-                os.path.join(path, "calib_velo_to_cam", f"{idx:06d}.txt"),
+            load_calib_cam_to_cam(
                 os.path.join(path, "calib_cam_to_cam", f"{idx:06d}.txt"),
+                os.path.join(path, "calib_velo_to_cam", f"{idx:06d}.txt"),
             )
         )
 
@@ -441,5 +336,4 @@ if __name__ == "__main__":
 
     dataset = KittiStereoFlowSFlow2015(sequence_start=10, sequence_end=11, grayscale=False)
     obj = dataset.getitem(randint(0, len(dataset)))
-    print(obj["left"].scene_flow)
     obj["left"].get_view().render()

--- a/alodataset/kitti_stereo_flow_sflow2015.py
+++ b/alodataset/kitti_stereo_flow_sflow2015.py
@@ -206,12 +206,12 @@ class KittiStereoFlowSFlow2015(BaseDataset, SplitMixin):
                 if "disp_noc" in self.load:
                     sequence[11]["left"].append_disparity(
                         self.load_disp(os.path.join(self.split_folder, f"disp_noc_1/{idx:06d}_10.png"), "left"),
-                        "disp_noc",
+                        "warped_disp_noc",
                     )
                 if "disp_occ" in self.load:
                     sequence[11]["left"].append_disparity(
                         self.load_disp(os.path.join(self.split_folder, f"disp_occ_1/{idx:06d}_10.png"), "left"),
-                        "disp_occ",
+                        "warped_disp_occ",
                     )
             if index == 10:
                 if "disp_noc" in self.load:

--- a/alodataset/kitti_stereo_flow_sflow2015.py
+++ b/alodataset/kitti_stereo_flow_sflow2015.py
@@ -36,7 +36,7 @@ class KittiStereoFlowSFlow2015(BaseDataset, SplitMixin):
         self.load = load
 
         if self.sample:
-            return
+            raise NotImplementedError("Sample mode is not implemented for KittiStereoFlowSFlow2015")
 
         assert sequence_start <= sequence_end, "sequence_start should be less than sequence_end"
 

--- a/alodataset/kitti_stereo_flow_sflow2015.py
+++ b/alodataset/kitti_stereo_flow_sflow2015.py
@@ -434,6 +434,6 @@ if __name__ == "__main__":
     from random import randint
 
     dataset = KittiStereoFlowSFlow2015(sequence_start=8, sequence_end=12, grayscale=False)
-    obj = dataset.getitem(1)
-    # print(obj)
-    obj["right"].get_view().render()
+    obj = dataset.getitem(randint(0, len(dataset)))
+    print(obj)
+    obj["left"].get_view().render()

--- a/alodataset/kitti_stereo_flow_sflow2015.py
+++ b/alodataset/kitti_stereo_flow_sflow2015.py
@@ -138,16 +138,7 @@ class KittiStereoFlowSFlow2015(BaseDataset, SplitMixin):
         scene_flow.nan_to_num_(0, 0, 0)
         return scene_flow
 
-    def getitem(self, idx):
-        """
-        Function for compatibility
-        Please check at getsequence
-        """
-        if self.sample:
-            return BaseDataset.__getitem__(self, idx)
-        return self.getsequence(idx)
-
-    def getsequence(self, idx) -> Dict[int, Dict[str, Frame]]:
+    def getitem(self, idx) -> Dict[int, Dict[str, Frame]]:
         """
         Load a sequence of frames from the dataset.
 
@@ -162,6 +153,9 @@ class KittiStereoFlowSFlow2015(BaseDataset, SplitMixin):
             Dictionary of index beetween sequance_start and sequance_end.\n
             Each index is a dictionary of frames ("left" and maybe "right").
         """
+        if self.sample:
+            return BaseDataset.__getitem__(self, idx)
+
         sequence: Dict[int, Dict[str, Frame]] = {}
         calib = self._load_calib(self.split_folder, idx)
 
@@ -411,7 +405,7 @@ class KittiStereoFlowSFlow2015(BaseDataset, SplitMixin):
 if __name__ == "__main__":
     from random import randint
 
-    dataset = KittiStereoFlowSFlow2015(sequence_start=8, sequence_end=12, grayscale=False)
+    dataset = KittiStereoFlowSFlow2015(sequence_start=10, sequence_end=11, grayscale=False)
     obj = dataset.getitem(randint(0, len(dataset)))
-    print(obj)
-    obj["left"].get_view().render()
+    print(obj["left"])
+    # obj["left"].get_view().render()

--- a/alodataset/kitti_stereo_flow_sflow2015.py
+++ b/alodataset/kitti_stereo_flow_sflow2015.py
@@ -117,48 +117,26 @@ class KittiStereoFlowSFlow2015(BaseDataset, SplitMixin):
             Scene flow beetween the two frames.
         """
 
-        size = frame.HW
-
         # Compute depth from disparity at time T
         disparity = frame.disparity["warped_disp_noc"]
         depth = disparity.as_depth(baseline=0.54, camera_intrinsic=frame.cam_intrinsic)
         depth.occlusion = disparity.mask.clone()
         depth.append_cam_extrinsic(frame.cam_extrinsic)
-        # frame.append_depth(depth)
 
         # Compute depth from disparity at time T+1
         disparity = next_frame.disparity["warped_disp_noc"]
         next_depth = disparity.as_depth(baseline=0.54, camera_intrinsic=next_frame.cam_intrinsic)
         next_depth.occlusion = disparity.mask.clone()
         next_depth.append_cam_extrinsic(next_frame.cam_extrinsic)
-        # next_frame.append_depth(next_depth)
 
-        # Compute the points cloud from the depth at time T
-        start_points = depth.as_points3d(camera_intrinsic=frame.cam_intrinsic).cpu().numpy()
-        mask = ~np.isfinite(start_points)
-        np.nan_to_num(start_points, copy=False, nan=-0.1, posinf=-0.1, neginf=-0.1)
+        # Remove the temporal dimension so depth and next_depth have the same shape.
+        next_depth = next_depth.squeeze(0)
 
-        # Compute the points cloud from the depth at time T+1
-        end_points = next_depth.as_points3d(camera_intrinsic=next_frame.cam_intrinsic).cpu().numpy()
-        mask = mask | ~np.isfinite(end_points)
-        np.nan_to_num(end_points, copy=False, nan=-0.1, posinf=-0.1, neginf=-0.1)
+        scene_flow = SceneFlow.from_optical_flow(frame.flow["flow_noc"], depth, next_depth, frame.cam_intrinsic)
 
-        # Compute the scene flow from the points cloud
-        mask = mask.any(axis=2)
-        scene_flow = end_points - start_points
-        scene_flow = scene_flow.transpose(0, 2, 1).reshape((1, 3, size[0], size[1]))
-
-        # Not sure if it is really usefull but here for security
-        start_occlusion = depth.occlusion.cpu().numpy().astype(bool)
-        end_occlusion = next_depth.occlusion.cpu().numpy().astype(bool)
-
-        # Fusion the occlusion mask
-        mask2 = end_occlusion | start_occlusion
-        mask = mask.reshape((1, size[0], size[1]))
-        mask = mask2 | mask
-        mask = Mask(mask, names=("T", "C", "H", "W"))
-
-        return SceneFlow(scene_flow, occlusion=mask, names=("T", "C", "H", "W"))
+        scene_flow.rename_(None, auto_restore_names=True)
+        scene_flow.nan_to_num_(0, 0, 0)
+        return scene_flow
 
     def getitem(self, idx):
         """

--- a/alodataset/kitti_stereo_flow_sflow2015.py
+++ b/alodataset/kitti_stereo_flow_sflow2015.py
@@ -1,0 +1,246 @@
+import os
+import cv2
+import torch
+import numpy as np
+from typing import Dict, List, Tuple
+
+from alodataset import BaseDataset, Split, SplitMixin
+from aloscene import Frame, Disparity, Mask, Flow, SceneFlow
+from aloscene.camera_calib import CameraIntrinsic, CameraExtrinsic
+
+
+class KittiStereoFlowSFlow2015(BaseDataset, SplitMixin):
+    SPLIT_FOLDERS = {Split.TRAIN: "training", Split.TEST: "testing"}
+
+    def __init__(
+        self,
+        name="kitti_stereo2015",
+        sequence_start=10,
+        sequence_end=11,
+        load: list = [
+            "right_frame",
+            "disp_noc",
+            "disp_occ",
+            "flow_occ",
+            "flow_noc",
+            "scene_flow",
+            "obj_map",
+        ],
+        **kwargs,
+    ):
+        super().__init__(name=name, **kwargs)
+        self.sequence_start = sequence_start
+        self.sequence_end = sequence_end
+        self.load = load
+
+        if self.sample:
+            return
+
+        assert sequence_start <= sequence_end, "sequence_start should be less than sequence_end"
+
+        if "disp_noc" in load or "disp_occ" in load:
+            assert sequence_start <= 11 and sequence_end >= 10, "Disparity is not available for this frame range"
+        if "flow_occ" in load or "flow_noc" in load:
+            assert sequence_start <= 10 and sequence_end >= 10, "Flow is not available for this frame range"
+        if "scene_flow" in load:
+            assert sequence_start <= 10 and sequence_end >= 11, "Scene flow is not available for this frame range"
+
+        # Load sequence length
+        self.split_folder = os.path.join(self.dataset_dir, self.get_split_folder())
+        left_img_folder = os.path.join(self.split_folder, "image_2")
+        self.len = len([f for f in os.listdir(left_img_folder) if f.endswith("_10.png")])
+
+    def __len__(self):
+        if self.sample:
+            return len(self.items)
+        return self.len
+
+    def load_disp(self, disp_path: str):
+        img = cv2.imread(disp_path, cv2.IMREAD_UNCHANGED)
+        disp = img / 256.0
+        disp = torch.as_tensor(disp[None, ...], dtype=torch.float32)
+        valid_mask = disp > 0
+        mask = Mask(valid_mask, names=("C", "H", "W"))
+        disp = Disparity(disp, names=("C", "H", "W"), mask=mask)
+        return disp
+
+    def load_flow(self, flow_path: str):
+        img = cv2.imread(flow_path, cv2.IMREAD_UNCHANGED)
+        valid_mask = img[..., 0] == 1
+        flow = (img - 2**15) / 64.0
+        flow = torch.as_tensor(flow[..., 1:], dtype=torch.float32).permute(2, 0, 1)
+        valid_mask = valid_mask.reshape((1, flow.shape[1], flow.shape[2]))
+        mask = Mask(valid_mask, names=("C", "H", "W"))
+        flow = Flow(flow, names=("C", "H", "W"), mask=mask)
+        return flow
+
+    def load_obj_map(self, path: str) -> List[Tuple[int, Mask]]:
+        img = cv2.imread(path, cv2.IMREAD_UNCHANGED)
+        result = []
+
+        # For each unique pixel value correspond a vehicule (execpt for 0)
+        for px_value in np.unique(img)[1:]:
+            result.append((px_value, Mask(np.array([img == px_value]), names=("C", "H", "W"))))
+
+        return result
+
+    @staticmethod
+    def _get_cam_intrinsic(size):
+        return CameraIntrinsic(focal_length=721.0, plane_size=size)
+
+    @staticmethod
+    def _fake_extrinsinc():
+        x = torch.eye(4, dtype=torch.float32)
+        return CameraExtrinsic(x)
+
+    def extrinsic(self, idx: int) -> CameraExtrinsic:
+        """Load extrinsic from corresponding file"""
+        with open(os.path.join(self.split_folder, f"calib_cam_to_cam/{idx:06d}.txt"), "r") as f:
+            file = f.readlines()
+            rotation = [float(x) for x in file[5].split(" ")[1:]]
+            translation = [float(x) for x in file[6].split(" ")[1:]]
+            rotation = np.array(rotation).reshape(3, 3)
+            translation = np.array(translation).reshape(3, 1)
+            extrinsic = np.append(rotation, translation, axis=1)
+            return CameraExtrinsic(np.append(extrinsic, np.array([[0, 0, 0, 1]]), axis=0))
+
+    def scene_flow_from_disp(self, frame: Frame, next_frame: Frame) -> SceneFlow:
+        """
+        Compute scene flow from the disparity of 2 frames
+
+        Parameters
+        ----------
+        frame : Frame
+            Frame at time T.
+        next_frame : Frame
+            Frame at time T+1.
+
+        Returns
+        -------
+        aloscene.SceneFlow
+            Scene flow beetween the two frames.
+        """
+
+        size = frame.HW
+
+        # Compute depth from disparity at time T
+        disparity = frame.disparity["disp_noc"]
+        depth = disparity.as_depth(baseline=0.54, camera_intrinsic=self._get_cam_intrinsic(size))
+        depth.occlusion = disparity.mask.clone()
+        depth.append_cam_extrinsic(self._fake_extrinsinc())
+        frame.append_depth(depth)
+
+        # Compute depth from disparity at time T+1
+        disparity = next_frame.disparity["disp_noc"]
+        next_depth = disparity.as_depth(baseline=0.54, camera_intrinsic=self._get_cam_intrinsic(size))
+        next_depth.occlusion = disparity.mask.clone()
+        next_depth.append_cam_extrinsic(self._fake_extrinsinc())
+        next_frame.append_depth(next_depth)
+
+        # Compute the points cloud from the depth at time T
+        start_points = depth.as_points3d(camera_intrinsic=self._get_cam_intrinsic(size)).cpu().numpy()
+        mask = ~np.isfinite(start_points)
+        np.nan_to_num(start_points, copy=False, nan=-0.1, posinf=-0.1, neginf=-0.1)
+
+        # Compute the points cloud from the depth at time T+1
+        end_points = next_depth.as_points3d(camera_intrinsic=self._get_cam_intrinsic(size)).cpu().numpy()
+        mask = mask | ~np.isfinite(end_points)
+        np.nan_to_num(end_points, copy=False, nan=-0.1, posinf=-0.1, neginf=-0.1)
+
+        # Compute the scene flow from the points cloud
+        mask = mask.any(axis=1)
+        scene_flow = end_points - start_points
+        scene_flow = scene_flow.reshape((size[0], size[1], 3))
+
+        # Not sure it is really usefull but here for security
+        start_occlusion = depth.occlusion.cpu().numpy().astype(bool)
+        end_occlusion = next_depth.occlusion.cpu().numpy().astype(bool)
+
+        # Fusion the occlusion mask
+        mask2 = end_occlusion | start_occlusion
+        mask = mask.reshape((size[0], size[1]))
+        mask2 = mask2.reshape((size[0], size[1]))
+        mask = mask2 | mask
+        mask = Mask(mask, names=("H", "W"))
+
+        return SceneFlow(scene_flow, occlusion=mask)
+
+    def getitem(self, idx):
+        """
+        Function for compatibility
+        Please check at getsequence
+        """
+        if self.sample:
+            return BaseDataset.__getitem__(self, idx)
+        return self.getsequance(idx)
+
+    def getsequance(self, idx) -> Dict[int, Dict[str, Frame]]:
+        """
+        Load a sequence of frames from the dataset.
+
+        Parameters
+        ----------
+        idx : int
+            Index of the sequence.
+
+        Returns
+        -------
+        Dict[int, Dict[str, Frame]]
+            Dictionary of index beetween sequance_start and sequance_end.\n
+            Each index is a dictionary of frames ("left" and maybe "right").
+        """
+        sequence: Dict[int, Dict[str, Frame]] = {}
+
+        # We need to load the sequance from the last to the first frame because we need information from the previous
+        # frame to compute the scene flow.
+        for index in range(self.sequence_end, self.sequence_start - 1, -1):
+            sequence[index] = {}
+            sequence[index]["left"] = Frame(os.path.join(self.split_folder, f"image_2/{idx:06d}_{index:02d}.png"))
+            size = sequence[index]["left"].HW
+            sequence[index]["left"].baseline = 0.54
+            sequence[index]["left"].append_cam_intrinsic(self._get_cam_intrinsic(size))
+            sequence[index]["left"].append_cam_extrinsic(self.extrinsic(idx))
+            if "right" in self.load:
+                sequence[index]["right"] = Frame(os.path.join(self.split_folder, f"image_3/{idx:06d}_{index:02d}.png"))
+                sequence[index]["right"].baseline = 0.54
+                sequence[index]["right"].append_cam_intrinsic(self._get_cam_intrinsic(size))
+                sequence[index]["right"].append_cam_extrinsic(self.extrinsic(idx))
+
+            # Frames at index 10 and 11 are the only one who have ground truth in dataset.
+            if index == 11:
+                if "disp_noc" in self.load:
+                    sequence[11]["left"].append_disparity(
+                        self.load_disp(os.path.join(self.split_folder, f"disp_noc_1/{idx:06d}_10.png")), "disp_noc"
+                    )
+                if "disp_occ" in self.load:
+                    sequence[11]["left"].append_disparity(
+                        self.load_disp(os.path.join(self.split_folder, f"disp_occ_1/{idx:06d}_10.png")), "disp_occ"
+                    )
+            if index == 10:
+                if "disp_noc" in self.load:
+                    sequence[10]["left"].append_disparity(
+                        self.load_disp(os.path.join(self.split_folder, f"disp_noc_0/{idx:06d}_10.png")), "disp_noc"
+                    )
+                if "disp_occ" in self.load:
+                    sequence[10]["left"].append_disparity(
+                        self.load_disp(os.path.join(self.split_folder, f"disp_occ_0/{idx:06d}_10.png")), "disp_occ"
+                    )
+                if "flow_occ" in self.load:
+                    sequence[10]["left"].append_flow(
+                        self.load_flow(os.path.join(self.split_folder, f"flow_occ/{idx:06d}_10.png")), "flow_occ"
+                    )
+                if "flow_noc" in self.load:
+                    sequence[10]["left"].append_flow(
+                        self.load_flow(os.path.join(self.split_folder, f"flow_noc/{idx:06d}_10.png")), "flow_noc"
+                    )
+                if "scene_flow" in self.load:
+                    # The scene flow cannot be added currently because of a bug in his representation.
+                    scene_flow = self.scene_flow_from_disp(sequence[10]["left"], sequence[11]["left"])
+                    # sequence[10]["left"].append_scene_flow(scene_flow)
+                if "obj_map" in self.load:
+                    for vehicule in self.load_obj_map(
+                        os.path.join(self.split_folder, f"obj_map/{idx:06d}_10.png")
+                    ):
+                        sequence[10]["left"].append_mask(vehicule[1], str(vehicule[0]))
+
+        return sequence

--- a/alodataset/kitti_tracking.py
+++ b/alodataset/kitti_tracking.py
@@ -201,9 +201,7 @@ class KittiTrackingDataset(BaseDataset, SplitMixin):
                 )
             )
             labels = Labels(labels, labels_names=["boxes"])
-            bounding_box = BoundingBoxes2D(
-                boxes2d, boxes_format="xyxy", absolute=True, frame_size=left_frame.HW
-            )
+            bounding_box = BoundingBoxes2D(boxes2d, boxes_format="xyxy", absolute=True, frame_size=left_frame.HW)
             bounding_box.append_labels(labels, "id")
             bounding_box.append_labels(Labels(categories, labels_names=LABELS), "categories")
             boxe3d = BoundingBoxes3D(boxes3d)
@@ -291,11 +289,11 @@ class KittiTrackingDataset(BaseDataset, SplitMixin):
         data["T3"] = T3
 
         # Compute the velodyne to rectified camera coordinate transforms
-        data['T_cam0_velo'] = np.reshape(filedata['Tr_velo_cam'], (3, 4))
-        data['T_cam0_velo'] = np.vstack([data['T_cam0_velo'], [0, 0, 0, 1]])
-        data['T_cam1_velo'] = T1.dot(data['T_cam0_velo'])
-        data['T_cam2_velo'] = T2.dot(data['T_cam0_velo'])
-        data['T_cam3_velo'] = T3.dot(data['T_cam0_velo'])
+        data["T_cam0_velo"] = np.reshape(filedata["Tr_velo_cam"], (3, 4))
+        data["T_cam0_velo"] = np.vstack([data["T_cam0_velo"], [0, 0, 0, 1]])
+        data["T_cam1_velo"] = T1.dot(data["T_cam0_velo"])
+        data["T_cam2_velo"] = T2.dot(data["T_cam0_velo"])
+        data["T_cam3_velo"] = T3.dot(data["T_cam0_velo"])
 
         # Compute the camera intrinsics
         data["K_cam0"] = P_rect_00[0:3, 0:3]
@@ -307,13 +305,13 @@ class KittiTrackingDataset(BaseDataset, SplitMixin):
         # each camera frame into the velodyne frame and computing the distances
         # between them
         p_cam = np.array([0, 0, 0, 1])
-        p_velo0 = np.linalg.inv(data['T_cam0_velo']).dot(p_cam)
-        p_velo1 = np.linalg.inv(data['T_cam1_velo']).dot(p_cam)
-        p_velo2 = np.linalg.inv(data['T_cam2_velo']).dot(p_cam)
-        p_velo3 = np.linalg.inv(data['T_cam3_velo']).dot(p_cam)
+        p_velo0 = np.linalg.inv(data["T_cam0_velo"]).dot(p_cam)
+        p_velo1 = np.linalg.inv(data["T_cam1_velo"]).dot(p_cam)
+        p_velo2 = np.linalg.inv(data["T_cam2_velo"]).dot(p_cam)
+        p_velo3 = np.linalg.inv(data["T_cam3_velo"]).dot(p_cam)
 
-        data['b_gray'] = np.linalg.norm(p_velo1 - p_velo0)  # gray baseline
-        data['b_rgb'] = np.linalg.norm(p_velo3 - p_velo2)   # rgb baseline
+        data["b_gray"] = np.linalg.norm(p_velo1 - p_velo0)  # gray baseline
+        data["b_rgb"] = np.linalg.norm(p_velo3 - p_velo2)  # rgb baseline
 
         # Return only the parameters we care.
         result = {
@@ -321,7 +319,7 @@ class KittiTrackingDataset(BaseDataset, SplitMixin):
             "right_intrinsic": np.c_[data["K_cam3"], [0, 0, 0]],
             "left_extrinsic": data["T2"],
             "right_extrinsic": data["T3"],
-            "baseline": data['b_rgb'],
+            "baseline": data["b_rgb"],
         }
         return result
 

--- a/alodataset/kitti_tracking.py
+++ b/alodataset/kitti_tracking.py
@@ -1,0 +1,305 @@
+import os
+import torch
+import numpy as np
+from typing import List, Dict, Any, Union
+
+from alodataset import BaseDataset, SplitMixin, Split
+from aloscene import Frame, Pose, CameraIntrinsic, CameraExtrinsic, BoundingBoxes2D, Labels, BoundingBoxes3D
+
+
+def sequence_index(start, seq_size, skip):
+    end = start + (seq_size - 1) * (skip + 1)
+    return np.linspace(start, end, seq_size).astype(int).tolist()
+
+
+def sequence_indices(n_samples, seq_size, skip, seq_skip):
+    for start in range(0, n_samples - (seq_size - 1) * (skip + 1), seq_skip + 1):
+        yield sequence_index(start, seq_size, skip)
+
+
+class KittiTrackingDataset(BaseDataset, SplitMixin):
+    SPLIT_FOLDERS = {Split.TRAIN: "training", Split.TEST: "testing"}
+
+    def __init__(
+        self,
+        name="kitti_tracking",
+        sequences: Union[int, List[int], None] = None,
+        right_frame=True,
+        sequence_size=3,
+        skip=1,
+        sequence_skip=1,
+        **kwargs,
+    ):
+        super().__init__(name=name, **kwargs)
+
+        self.right_frame = right_frame
+        self.sequence_size = sequence_size
+        self.skip = skip
+        self.sequence_skip = sequence_skip
+
+        if self.sample:
+            return
+
+        self.dataset_dir = os.path.join(self.dataset_dir, self.get_split_folder())
+
+        self.sequences = self._load_sequences(sequences)
+
+        self.items: Dict[Any, Any] = {}
+
+        self.seq_params = {}
+
+        for seq in self.sequences:
+
+            # Exploit data from calib.txt
+            calib = self._load_calib(os.path.join(self.dataset_dir, "calib", f"{seq}.txt"))
+
+            # Register sequence parameters
+            # self.seq_params["baseline"] = calib"b_gra"_rgb"]
+            self.seq_params["left_intrinsic"] = calib["left_intrinsic"]
+            self.seq_params["left_extrinsic"] = calib["left_extrinsic"]
+            if right_frame:
+                self.seq_params["right_intrinsic"] = calib["right_intrinsic"]
+                self.seq_params["right_extrinsic"] = calib["right_extrinsic"]
+
+            with open(os.path.join(self.dataset_dir, "label_02", f"{seq}.txt"), "r") as f:
+                labels = []
+                for line in f:
+                    line = line.split()
+                    if int(line[0]) == len(labels):
+                        labels.append([])
+                    labels[-1].append(line[1:])
+
+            # Compute all the items.
+            sequence_size = len(labels)
+
+            # Compute sequence indices
+            temporal_sequences = sequence_indices(sequence_size, self.sequence_size, self.skip, self.sequence_skip)
+            self.items.update(
+                {
+                    len(self.items)
+                    + idx: {
+                        "sequence": seq,
+                        "temporal_sequence": temporal_seq,
+                        "labels": [labels[x] for x in temporal_seq] if labels else None,
+                    }
+                    for idx, temporal_seq in enumerate(temporal_sequences)
+                }
+            )
+
+    def __len__(self):
+        return len(self.items)
+
+    def _load_sequences(self, sequences) -> List[str]:
+        loaded_sequences = []
+
+        if sequences is None:
+            for seq in sorted(os.listdir(os.path.join(self.dataset_dir, "image_02"))):
+                if (int(seq) <= 10 and self.split == Split.TRAIN) or (int(seq) >= 11 and self.split == Split.VAL):
+                    loaded_sequences.append(seq)
+        elif isinstance(sequences, int):
+            if not os.path.exists(os.path.join(self.dataset_dir, "image_02", f"{sequences:02d}")):
+                raise ValueError(f"Sequence {sequences:04} does not exist")
+            if (sequences <= 10 and self.split == Split.VAL) or (sequences >= 11 and self.split == Split.TRAIN):
+                raise ValueError(f"Sequence {sequences:04d} is not in the {self.split} split")
+            loaded_sequences.append(f"{sequences:04d}")
+        elif isinstance(sequences, str):
+            if not os.path.exists(os.path.join(self.dataset_dir, "image_02", sequences)):
+                raise ValueError(f"Sequence {sequences} does not exist")
+            if (int(sequences) <= 10 and self.split == Split.VAL) or (
+                int(sequences) >= 11 and self.split == Split.TRAIN
+            ):
+                raise ValueError(f"Sequence {sequences} is not in the {self.split} split")
+            loaded_sequences.append(sequences)
+        elif isinstance(sequences, list):
+            for seq in sequences:
+                seq = f"{seq:04d}" if isinstance(seq, int) else seq
+                if not os.path.exists(os.path.join(self.dataset_dir, "image_02", seq)):
+                    raise ValueError(f"Sequence {seq} does not exist")
+                if (int(seq) <= 10 and self.split == Split.VAL) or (int(seq) >= 11 and self.split == Split.TRAIN):
+                    raise ValueError(f"Sequence {seq} is not in the {self.split} split")
+                loaded_sequences.append(seq)
+
+        return loaded_sequences
+
+    @staticmethod
+    def _get_cam_intrinsic(size):
+        return CameraIntrinsic(focal_length=721.0, plane_size=size)
+
+    @staticmethod
+    def _fake_extrinsinc():
+        x = torch.eye(4, dtype=torch.float32)
+        return CameraExtrinsic(x)
+
+    def getitem(self, idx: int):
+        """
+        Loads a single frame from the dataset.
+
+        Parameters
+        ----------
+        idx : int
+            Index of the frame to load.
+
+        Returns
+        -------
+        Dict[str, Frame]
+            Dictionary with the loaded frame and pose.
+        """
+
+        if self.sample:
+            return BaseDataset.__getitem__(self, idx)
+
+        item = self.items[idx]
+
+        left = []
+        right = []
+        sequence: str = item["sequence"]  # Number of the sequence
+
+        for id, seq in enumerate(item["temporal_sequence"]):
+
+            labels = []
+            boxes2d = []
+            boxes3d = []
+
+            for box in item["labels"][id]:
+                x, y, w, h = float(box[5]), float(box[6]), float(box[7]), float(box[8])
+                boxes2d.append([x, y, w, h])
+                labels.append(int(box[0]))
+
+                # If the object caterory is "Don't care" (index -1) there is no 3D box.
+                if box[0] != "-1":
+                    print(box)
+                    boxes3d.append(
+                        [
+                            float(box[12]),
+                            # The center of the 3d box on Kitty is the center of the bottom face. We need to
+                            # move it up by half the height of the box to correspond to the center of the box.
+                            # Check kitti_tracking devkit for more info.
+                            float(box[13]) - float(box[9]) / 2,
+                            float(box[14]),
+                            float(box[10]),
+                            float(box[9]),
+                            float(box[11]),
+                            # The rotation of the 3d box on Kitty is based on the X axis. We need to rotate it
+                            # to have same the rotation wanted by BoundingBoxes3D.
+                            # Check kitti_object devkit for more info.
+                            float(box[15]) + np.pi / 2,
+                        ]
+                    )
+
+            left_frame = Frame(
+                os.path.join(
+                    self.dataset_dir,
+                    "image_02",
+                    sequence,
+                    f"{seq:06d}.png",
+                )
+            )
+            labels = Labels(labels, labels_names=["boxes"])
+            bounding_box = BoundingBoxes2D(
+                boxes2d, boxes_format="xyxy", absolute=True, frame_size=left_frame.HW, labels=labels
+            )
+            boxe3d = BoundingBoxes3D(boxes3d)
+            left_frame.append_boxes3d(boxe3d)
+            left_frame.append_boxes2d(bounding_box)
+            left_frame.append_cam_extrinsic(CameraExtrinsic(self.seq_params["left_extrinsic"]))
+            left_frame.append_cam_intrinsic(CameraIntrinsic(self.seq_params["left_intrinsic"]))
+
+            # Need to create temporal dimension for future fusion.
+            left.append(left_frame.temporal())
+
+            if self.right_frame:
+                right_frame = Frame(
+                    os.path.join(
+                        self.dataset_dir,
+                        "image_03",
+                        sequence,
+                        f"{seq:06d}.png",
+                    )
+                )
+                right_frame.append_cam_intrinsic(CameraIntrinsic(self.seq_params["right_intrinsic"]))
+                right_frame.append_cam_extrinsic(CameraExtrinsic(self.seq_params["right_extrinsic"]))
+                right.append(right_frame.temporal())
+
+        frames = {}
+        frames["left"] = torch.cat(left, dim=0)
+
+        if self.right_frame:
+            frames["right"] = torch.cat(right, dim=0)
+
+        return frames
+
+    # https://github.com/utiasSTARS/pykitti/tree/master
+    def read_calib_file(self, filepath):
+        """Read in a calibration file and parse into a dictionary."""
+        data = {}
+
+        with open(filepath, "r") as f:
+            for line in f.readlines():
+                if not ":" in line:
+                    break
+                key, value = line.split(":", 1)
+                # The only non-float values in these files are dates, which
+                # we don't care about anyway
+                try:
+                    data[key] = np.array([float(x) for x in value.split()])
+                except ValueError:
+                    pass
+
+        return data
+
+    def _load_calib(self, calib_filepath):
+        """Load and compute intrinsic and extrinsic calibration parameters."""
+        # We'll build the calibration parameters as a dictionary, then
+        # convert it to a namedtuple to prevent it from being modified later
+        data = {}
+
+        # Load the calibration file
+        filedata = self.read_calib_file(calib_filepath)
+
+        # Create 3x4 projection matrices
+        P_rect_00 = np.reshape(filedata["P0"], (3, 4))
+        P_rect_10 = np.reshape(filedata["P1"], (3, 4))
+        P_rect_20 = np.reshape(filedata["P2"], (3, 4))
+        P_rect_30 = np.reshape(filedata["P3"], (3, 4))
+
+        data["P_rect_00"] = P_rect_00
+        data["P_rect_10"] = P_rect_10
+        data["P_rect_20"] = P_rect_20
+        data["P_rect_30"] = P_rect_30
+
+        # Compute the rectified extrinsics from cam0 to camN
+        T0 = np.eye(4)
+        T0[0, 3] = P_rect_00[0, 3] / P_rect_00[0, 0]
+        T1 = np.eye(4)
+        T1[0, 3] = P_rect_10[0, 3] / P_rect_10[0, 0]
+        T2 = np.eye(4)
+        T2[0, 3] = P_rect_20[0, 3] / P_rect_20[0, 0]
+        T3 = np.eye(4)
+        T3[0, 3] = P_rect_30[0, 3] / P_rect_30[0, 0]
+
+        data["T0"] = T0
+        data["T1"] = T1
+        data["T2"] = T2
+        data["T3"] = T3
+
+        # Compute the camera intrinsics
+        data["K_cam0"] = P_rect_00[0:3, 0:3]
+        data["K_cam1"] = P_rect_10[0:3, 0:3]
+        data["K_cam2"] = P_rect_20[0:3, 0:3]
+        data["K_cam3"] = P_rect_30[0:3, 0:3]
+
+        # Return only the parameters we care.
+        result = {
+            "left_intrinsic": np.c_[data["K_cam2"], [0, 0, 0]],
+            "right_intrinsic": np.c_[data["K_cam3"], [0, 0, 0]],
+            "left_extrinsic": data["T2"],
+            "right_extrinsic": data["T3"],
+        }
+        return result
+
+
+if __name__ == "__main__":
+    tracking = KittiTrackingDataset(sequences=[0], right_frame=False, sequence_size=4, sequence_skip=40, skip=17)
+    r = tracking.getitem(0)
+    print("tensor", r["left"].HW, r["left"].boxes3d, "\ntotal", r)
+    r["left"].get_view().render()

--- a/alodataset/kitti_tracking.py
+++ b/alodataset/kitti_tracking.py
@@ -6,7 +6,8 @@ from collections import defaultdict
 
 from alodataset import BaseDataset, SplitMixin, Split
 from aloscene import Frame, CameraIntrinsic, CameraExtrinsic, BoundingBoxes2D, Labels, BoundingBoxes3D
-import aloscene
+
+from alodataset.utils.kitti import load_calib_cam_to_cam
 
 LABELS = ["Car", "Van", "Truck", "Pedestrian", "Person_sitting", "Cyclist", "Tram", "Misc", "DontCare"]
 
@@ -227,95 +228,23 @@ class KittiTrackingDataset(BaseDataset, SplitMixin):
 
         return frames
 
-    # https://github.com/utiasSTARS/pykitti/tree/master
-    def read_calib_file(self, filepath):
-        """Read in a calibration file and parse into a dictionary."""
-        data = {}
-
-        with open(filepath, "r") as f:
-            for line in f.readlines():
-                key, value = line.split(" ", 1)
-                key = key.strip(":")
-                # The only non-float values in these files are dates, which
-                # we don't care about anyway
-                try:
-                    data[key] = np.array([float(x) for x in value.split()])
-                except ValueError:
-                    pass
-        return data
-
     def _load_calib(self, calib_filepath):
-        """Load and compute intrinsic and extrinsic calibration parameters."""
-        # We'll build the calibration parameters as a dictionary, then
-        # convert it to a namedtuple to prevent it from being modified later
-        data = {}
-
-        # Load the calibration file
-        filedata = self.read_calib_file(calib_filepath)
-
-        # Create 3x4 projection matrices
-        P_rect_00 = np.reshape(filedata["P0"], (3, 4))
-        P_rect_10 = np.reshape(filedata["P1"], (3, 4))
-        P_rect_20 = np.reshape(filedata["P2"], (3, 4))
-        P_rect_30 = np.reshape(filedata["P3"], (3, 4))
-
-        data["P_rect_00"] = P_rect_00
-        data["P_rect_10"] = P_rect_10
-        data["P_rect_20"] = P_rect_20
-        data["P_rect_30"] = P_rect_30
-
-        # Compute the rectified extrinsics from cam0 to camN
-        T0 = np.eye(4)
-        T0[0, 3] = P_rect_00[0, 3] / P_rect_00[0, 0]
-        T1 = np.eye(4)
-        T1[0, 3] = P_rect_10[0, 3] / P_rect_10[0, 0]
-        T2 = np.eye(4)
-        T2[0, 3] = P_rect_20[0, 3] / P_rect_20[0, 0]
-        T3 = np.eye(4)
-        T3[0, 3] = P_rect_30[0, 3] / P_rect_30[0, 0]
-
-        data["T0"] = T0
-        data["T1"] = T1
-        data["T2"] = T2
-        data["T3"] = T3
-
-        # Compute the velodyne to rectified camera coordinate transforms
-        data["T_cam0_velo"] = np.reshape(filedata["Tr_velo_cam"], (3, 4))
-        data["T_cam0_velo"] = np.vstack([data["T_cam0_velo"], [0, 0, 0, 1]])
-        data["T_cam1_velo"] = T1.dot(data["T_cam0_velo"])
-        data["T_cam2_velo"] = T2.dot(data["T_cam0_velo"])
-        data["T_cam3_velo"] = T3.dot(data["T_cam0_velo"])
-
-        # Compute the camera intrinsics
-        data["K_cam0"] = P_rect_00[0:3, 0:3]
-        data["K_cam1"] = P_rect_10[0:3, 0:3]
-        data["K_cam2"] = P_rect_20[0:3, 0:3]
-        data["K_cam3"] = P_rect_30[0:3, 0:3]
-
-        # Compute the stereo baselines in meters by projecting the origin of
-        # each camera frame into the velodyne frame and computing the distances
-        # between them
-        p_cam = np.array([0, 0, 0, 1])
-        p_velo0 = np.linalg.inv(data["T_cam0_velo"]).dot(p_cam)
-        p_velo1 = np.linalg.inv(data["T_cam1_velo"]).dot(p_cam)
-        p_velo2 = np.linalg.inv(data["T_cam2_velo"]).dot(p_cam)
-        p_velo3 = np.linalg.inv(data["T_cam3_velo"]).dot(p_cam)
-
-        data["b_gray"] = np.linalg.norm(p_velo1 - p_velo0)  # gray baseline
-        data["b_rgb"] = np.linalg.norm(p_velo3 - p_velo2)  # rgb baseline
+        data = load_calib_cam_to_cam(calib_filepath)
 
         # Return only the parameters we care.
         result = {
             "left_intrinsic": np.c_[data["K_cam2"], [0, 0, 0]],
             "right_intrinsic": np.c_[data["K_cam3"], [0, 0, 0]],
-            "left_extrinsic": data["T2"],
-            "right_extrinsic": data["T3"],
+            "left_extrinsic": data["T_cam2_rect"],
+            "right_extrinsic": data["T_cam3_rect"],
             "baseline": data["b_rgb"],
         }
         return result
 
 
 if __name__ == "__main__":
-    tracking = KittiTrackingDataset(right_frame=False)
-    r = tracking.getitem(286)
-    r["left"].get_view().render()
+    from random import randint
+
+    dataset = KittiTrackingDataset(right_frame=False)
+    obj = dataset.getitem(randint(0, len(dataset)))
+    obj["left"].get_view().render()

--- a/alodataset/kitti_tracking.py
+++ b/alodataset/kitti_tracking.py
@@ -91,9 +91,6 @@ class KittiTrackingDataset(BaseDataset, SplitMixin):
                 }
             )
 
-    def __len__(self):
-        return len(self.items)
-
     def _load_sequences(self, sequences) -> List[str]:
         if sequences is None:
             sequences = []

--- a/alodataset/kitti_tracking.py
+++ b/alodataset/kitti_tracking.py
@@ -7,17 +7,7 @@ from collections import defaultdict
 from alodataset import BaseDataset, SplitMixin, Split
 from aloscene import Frame, CameraIntrinsic, CameraExtrinsic, BoundingBoxes2D, Labels, BoundingBoxes3D
 
-from alodataset.utils.kitti import load_calib_cam_to_cam
-
-
-def sequence_index(start, seq_size, skip):
-    end = start + (seq_size - 1) * (skip + 1)
-    return np.linspace(start, end, seq_size).astype(int).tolist()
-
-
-def sequence_indices(n_samples, seq_size, skip, seq_skip):
-    for start in range(0, n_samples - (seq_size - 1) * (skip + 1), seq_skip + 1):
-        yield sequence_index(start, seq_size, skip)
+from alodataset.utils.kitti import load_calib_cam_to_cam, sequence_indices
 
 
 class KittiTrackingDataset(BaseDataset, SplitMixin):

--- a/alodataset/kitti_tracking.py
+++ b/alodataset/kitti_tracking.py
@@ -231,7 +231,7 @@ class KittiTrackingDataset(BaseDataset, SplitMixin):
     def _load_calib(self, calib_filepath):
         data = load_calib_cam_to_cam(calib_filepath)
 
-        # Return only the parameters we care.
+        # Return only the parameters we are interested in.
         result = {
             "left_intrinsic": np.c_[data["K_cam2"], [0, 0, 0]],
             "right_intrinsic": np.c_[data["K_cam3"], [0, 0, 0]],

--- a/alodataset/kitti_tracking.py
+++ b/alodataset/kitti_tracking.py
@@ -55,14 +55,16 @@ class KittiTrackingDataset(BaseDataset, SplitMixin):
             # Exploit data from calib.txt
             calib = self._load_calib(os.path.join(self.dataset_dir, "calib", f"{seq}.txt"))
 
+            self.seq_params[seq] = {}
+
             # Register sequence parameters
-            # self.seq_params["baseline"] = calib"b_gra"_rgb"]
-            self.seq_params["left_intrinsic"] = calib["left_intrinsic"]
-            self.seq_params["left_extrinsic"] = calib["left_extrinsic"]
-            self.seq_params["baseline"] = calib["baseline"]
+            # self.seq_params[sequence]["baseline"] = calib"b_gra"_rgb"]
+            self.seq_params[seq]["left_intrinsic"] = calib["left_intrinsic"]
+            self.seq_params[seq]["left_extrinsic"] = calib["left_extrinsic"]
+            self.seq_params[seq]["baseline"] = calib["baseline"]
             if right_frame:
-                self.seq_params["right_intrinsic"] = calib["right_intrinsic"]
-                self.seq_params["right_extrinsic"] = calib["right_extrinsic"]
+                self.seq_params[seq]["right_intrinsic"] = calib["right_intrinsic"]
+                self.seq_params[seq]["right_extrinsic"] = calib["right_extrinsic"]
 
             with open(os.path.join(self.dataset_dir, "label_02", f"{seq}.txt"), "r") as f:
                 labels = []
@@ -207,9 +209,9 @@ class KittiTrackingDataset(BaseDataset, SplitMixin):
             boxe3d = BoundingBoxes3D(boxes3d)
             left_frame.append_boxes3d(boxe3d)
             left_frame.append_boxes2d(bounding_box)
-            left_frame.append_cam_extrinsic(CameraExtrinsic(self.seq_params["left_extrinsic"]))
-            left_frame.append_cam_intrinsic(CameraIntrinsic(self.seq_params["left_intrinsic"]))
-            left_frame.baseline = self.seq_params["baseline"]
+            left_frame.append_cam_extrinsic(CameraExtrinsic(self.seq_params[sequence]["left_extrinsic"]))
+            left_frame.append_cam_intrinsic(CameraIntrinsic(self.seq_params[sequence]["left_intrinsic"]))
+            left_frame.baseline = self.seq_params[sequence]["baseline"]
 
             # Need to create temporal dimension for future fusion.
             left.append(left_frame.temporal())
@@ -223,9 +225,9 @@ class KittiTrackingDataset(BaseDataset, SplitMixin):
                         f"{seq:06d}.png",
                     )
                 )
-                right_frame.append_cam_intrinsic(CameraIntrinsic(self.seq_params["right_intrinsic"]))
-                right_frame.append_cam_extrinsic(CameraExtrinsic(self.seq_params["right_extrinsic"]))
-                right_frame.baseline = self.seq_params["baseline"]
+                right_frame.append_cam_intrinsic(CameraIntrinsic(self.seq_params[sequence]["right_intrinsic"]))
+                right_frame.append_cam_extrinsic(CameraExtrinsic(self.seq_params[sequence]["right_extrinsic"]))
+                right_frame.baseline = self.seq_params[sequence]["baseline"]
                 right.append(right_frame.temporal())
 
         frames = {}

--- a/alodataset/kitti_tracking.py
+++ b/alodataset/kitti_tracking.py
@@ -9,8 +9,6 @@ from aloscene import Frame, CameraIntrinsic, CameraExtrinsic, BoundingBoxes2D, L
 
 from alodataset.utils.kitti import load_calib_cam_to_cam
 
-LABELS = ["Car", "Van", "Truck", "Pedestrian", "Person_sitting", "Cyclist", "Tram", "Misc", "DontCare"]
-
 
 def sequence_index(start, seq_size, skip):
     end = start + (seq_size - 1) * (skip + 1)
@@ -24,6 +22,7 @@ def sequence_indices(n_samples, seq_size, skip, seq_skip):
 
 class KittiTrackingDataset(BaseDataset, SplitMixin):
     SPLIT_FOLDERS = {Split.TRAIN: "training", Split.TEST: "testing"}
+    LABELS = ["Car", "Van", "Truck", "Pedestrian", "Person_sitting", "Cyclist", "Tram", "Misc", "DontCare"]
 
     def __init__(
         self,
@@ -153,7 +152,7 @@ class KittiTrackingDataset(BaseDataset, SplitMixin):
                 x, y, w, h = float(box[5]), float(box[6]), float(box[7]), float(box[8])
                 boxes2d.append([x, y, w, h])
                 labels.append(int(box[0]))  # track_id
-                categories.append(LABELS.index(box[1]))  # type
+                categories.append(self.LABELS.index(box[1]))  # type
 
                 # If the object caterory is "Don't care", there is no 3D box.
                 if box[1] != "DontCare":
@@ -175,7 +174,7 @@ class KittiTrackingDataset(BaseDataset, SplitMixin):
                         ]
                     )
                     labels_3d.append(int(box[0]))  # track_id
-                    categories_3d.append(LABELS.index(box[1]))  # type
+                    categories_3d.append(self.LABELS.index(box[1]))  # type
 
             left_frame = Frame(
                 os.path.join(
@@ -190,12 +189,13 @@ class KittiTrackingDataset(BaseDataset, SplitMixin):
                 labels = Labels(labels, labels_names=["boxes"])
                 bounding_box = BoundingBoxes2D(boxes2d, boxes_format="xyxy", absolute=True, frame_size=left_frame.HW)
                 bounding_box.append_labels(labels, "track_id")
-                bounding_box.append_labels(Labels(categories, labels_names=LABELS), "categories")
+                bounding_box.append_labels(Labels(categories, labels_names=self.LABELS), "categories")
                 left_frame.append_boxes2d(bounding_box)
             if boxes3d:
                 labels_3d = Labels(labels_3d, labels_names=["boxes"])
                 boxe3d = BoundingBoxes3D(
-                    boxes3d, labels={"track_id": labels_3d, "categories": Labels(categories_3d, labels_names=LABELS)}
+                    boxes3d,
+                    labels={"track_id": labels_3d, "categories": Labels(categories_3d, labels_names=self.LABELS)},
                 )
                 left_frame.append_boxes3d(boxe3d)
 

--- a/alodataset/kitti_tracking.py
+++ b/alodataset/kitti_tracking.py
@@ -42,7 +42,7 @@ class KittiTrackingDataset(BaseDataset, SplitMixin):
         self.sequence_skip = sequence_skip
 
         if self.sample:
-            return
+            raise NotImplementedError("Sample mode is not implemented for KittiTrackingDataset")
 
         self.dataset_dir = os.path.join(self.dataset_dir, self.get_split_folder())
 

--- a/alodataset/utils/kitti.py
+++ b/alodataset/utils/kitti.py
@@ -72,12 +72,12 @@ def load_calib_cam_to_cam(cam_to_cam_filepath, velo_to_cam_file: Union[str, None
 
     # Load the rigid transformation from velodyne coordinates
     # to unrectified cam0 coordinates
-    T_cam0unrect_velo = None
+    t_cam0unrect_velo = None
     stereo_baseline = None
     if velo_to_cam_file is not None and r_rect is not None:
-        T_cam0unrect_velo = load_calib_rigid(velo_to_cam_file)
+        t_cam0unrect_velo = load_calib_rigid(velo_to_cam_file)
 
-        velo_to_cam = [rectified_extrinsics[i].dot(r_rect[i].dot(T_cam0unrect_velo)) for i in range(4)]
+        velo_to_cam = [rectified_extrinsics[i].dot(r_rect[i].dot(t_cam0unrect_velo)) for i in range(4)]
         p_cam = np.array([0, 0, 0, 1])
         stereo_baseline = [np.linalg.inv(velo_to_cam[i]).dot(p_cam) for i in range(4)]
 

--- a/alodataset/utils/kitti.py
+++ b/alodataset/utils/kitti.py
@@ -2,6 +2,16 @@ import numpy as np
 from typing import Union
 
 
+def sequence_index(start, seq_size, skip):
+    end = start + (seq_size - 1) * (skip + 1)
+    return np.linspace(start, end, seq_size).astype(int).tolist()
+
+
+def sequence_indices(n_samples, seq_size, skip, seq_skip):
+    for start in range(0, n_samples - (seq_size - 1) * (skip + 1), seq_skip + 1):
+        yield sequence_index(start, seq_size, skip)
+
+
 # https://github.com/utiasSTARS/pykitti/tree/master
 def read_calib_file(filepath):
     """Read in a calibration file and parse into a dictionary."""

--- a/alodataset/utils/kitti.py
+++ b/alodataset/utils/kitti.py
@@ -1,0 +1,158 @@
+import numpy as np
+from typing import Union
+
+
+# https://github.com/utiasSTARS/pykitti/tree/master
+def read_calib_file(filepath):
+    """Read in a calibration file and parse into a dictionary."""
+    data = {}
+
+    with open(filepath, "r") as f:
+        for line in f.readlines():
+            if line == "\n":
+                continue
+            key, value = line.split(" ", 1)
+            key = key.strip(":")
+            # The only non-float values in these files are dates, which
+            # we don't care about anyway
+            try:
+                data[key] = np.array([float(x) for x in value.split()])
+            except ValueError:
+                pass
+
+    return data
+
+
+def transform_from_rot_trans(R, t):
+    """Transforation matrix from rotation matrix and translation vector."""
+    R = R.reshape(3, 3)
+    t = t.reshape(3, 1)
+    return np.vstack((np.hstack([R, t]), [0, 0, 0, 1]))
+
+
+def load_calib_rigid(filepath):
+    """Read a rigid transform calibration file as a numpy.array."""
+    data = read_calib_file(filepath)
+    return transform_from_rot_trans(data["R"], data["T"])
+
+
+def load_calib_cam_to_cam(cam_to_cam_filepath, velo_to_cam_file: Union[str, None] = None):
+    # We'll return the camera calibration as a dictionary
+    data = {}
+
+    # Load and parse the cam-to-cam calibration data
+    filedata = read_calib_file(cam_to_cam_filepath)
+
+    names = ["P_rect_00", "P_rect_01", "P_rect_02", "P_rect_03"]
+    if "P0" in filedata:
+        names = ["P0", "P1", "P2", "P3"]
+
+    # Create 3x4 projection matrices
+    """P_rect_00 = np.reshape(filedata["P_rect_00"], (3, 4))
+    P_rect_10 = np.reshape(filedata["P_rect_01"], (3, 4))
+    P_rect_20 = np.reshape(filedata["P_rect_02"], (3, 4))
+    P_rect_30 = np.reshape(filedata["P_rect_03"], (3, 4))"""
+    p_rect = [np.reshape(filedata[p], (3, 4)) for p in names]
+
+    """data["P_rect_00"] = P_rect_00
+    data["P_rect_10"] = P_rect_10
+    data["P_rect_20"] = P_rect_20
+    data["P_rect_30"] = P_rect_30"""
+    for i, p in enumerate(p_rect):
+        data[f"P_rect_{i}0"] = p
+
+    # Compute the rectified extrinsics from cam0 to camN
+    """T0 = np.eye(4)
+    T0[0, 3] = P_rect_00[0, 3] / P_rect_00[0, 0]
+    T1 = np.eye(4)
+    T1[0, 3] = P_rect_10[0, 3] / P_rect_10[0, 0]
+    T2 = np.eye(4)
+    T2[0, 3] = P_rect_20[0, 3] / P_rect_20[0, 0]
+    T3 = np.eye(4)
+    T3[0, 3] = P_rect_30[0, 3] / P_rect_30[0, 0]"""
+
+    rectified_extrinsics = [np.eye(4) for _ in range(4)]
+    for i in range(4):
+        rectified_extrinsics[i][0, 3] = p_rect[i][0, 3] / p_rect[i][0, 0]
+        data[f"T_cam{i}_rect"] = rectified_extrinsics[i]
+        data[f"K_cam{i}"] = p_rect[i][0:3, 0:3]
+
+    # Create 4x4 matrices from the rectifying rotation matrices
+    """R_rect_00 = np.eye(4)
+    R_rect_00[0:3, 0:3] = np.reshape(filedata["R_rect_00"], (3, 3))
+    R_rect_10 = np.eye(4)
+    R_rect_10[0:3, 0:3] = np.reshape(filedata["R_rect_01"], (3, 3))
+    R_rect_20 = np.eye(4)
+    R_rect_20[0:3, 0:3] = np.reshape(filedata["R_rect_02"], (3, 3))
+    R_rect_30 = np.eye(4)
+    R_rect_30[0:3, 0:3] = np.reshape(filedata["R_rect_03"], (3, 3))"""
+
+    r_rect = None
+    if "R_rect_00" in filedata:
+        r_rect = [np.eye(4) for _ in range(4)]
+        for i in range(4):
+            r_rect[i][0:3, 0:3] = np.reshape(filedata["R_rect_0" + str(i)], (3, 3))
+            data[f"R_rect_{i}0"] = r_rect[i]
+
+    """data["R_rect_00"] = R_rect_00
+    data["R_rect_10"] = R_rect_10
+    data["R_rect_20"] = R_rect_20
+    data["R_rect_30"] = R_rect_30
+
+    data["T_cam0_rect"] = T0
+    data["T_cam1_rect"] = T1
+    data["T_cam2_rect"] = T2
+    data["T_cam3_rect"] = T3"""
+
+    # Load the rigid transformation from velodyne coordinates
+    # to unrectified cam0 coordinates
+    T_cam0unrect_velo = None
+    if velo_to_cam_file is not None and r_rect is not None:
+        T_cam0unrect_velo = load_calib_rigid(velo_to_cam_file)
+
+        velo_to_cam = [rectified_extrinsics[i].dot(r_rect[i].dot(T_cam0unrect_velo)) for i in range(4)]
+        p_cam = np.array([0, 0, 0, 1])
+        stereo_baseline = [np.linalg.inv(velo_to_cam[i]).dot(p_cam) for i in range(4)]
+        data["b_gray"] = np.linalg.norm(stereo_baseline[1] - stereo_baseline[0])
+        data["b_rgb"] = np.linalg.norm(stereo_baseline[3] - stereo_baseline[2])
+
+        for i in range(4):
+            data[f"T_cam{i}_velo"] = velo_to_cam[i]
+
+    elif "Tr_velo_to_cam" in filedata or "Tr_velo_cam" in filedata or "Tr" in filedata:
+        prop_name = (
+            "Tr_velo_to_cam" if "Tr_velo_to_cam" in filedata else "Tr_velo_cam" if "Tr_velo_cam" in filedata else "Tr"
+        )
+        data["T_cam0_velo"] = np.reshape(filedata[prop_name], (3, 4))
+        data["T_cam0_velo"] = np.vstack([data["T_cam0_velo"], [0, 0, 0, 1]])
+        for i in range(1, 4):
+            data[f"T_cam{i}_velo"] = rectified_extrinsics[i].dot(data["T_cam0_velo"])
+        p_cam = np.array([0, 0, 0, 1])
+        stereo_baseline = [np.linalg.inv(data[f"T_cam{i}_velo"]).dot(p_cam) for i in range(4)]
+        data["b_gray"] = np.linalg.norm(stereo_baseline[1] - stereo_baseline[0])
+        data["b_rgb"] = np.linalg.norm(stereo_baseline[3] - stereo_baseline[2])
+
+    """data["T_cam0_velo"] = T0.dot(R_rect_00.dot(T_cam0unrect_velo))
+    data["T_cam1_velo"] = T1.dot(R_rect_00.dot(T_cam0unrect_velo))
+    data["T_cam2_velo"] = T2.dot(R_rect_00.dot(T_cam0unrect_velo))
+    data["T_cam3_velo"] = T3.dot(R_rect_00.dot(T_cam0unrect_velo))"""
+
+    # Compute the camera intrinsics
+    """data["K_cam0"] = P_rect_00[0:3, 0:3]
+    data["K_cam1"] = P_rect_10[0:3, 0:3]
+    data["K_cam2"] = P_rect_20[0:3, 0:3]
+    data["K_cam3"] = P_rect_30[0:3, 0:3]"""
+
+    # Compute the stereo baselines in meters by projecting the origin of
+    # each camera frame into the velodyne frame and computing the distances
+    # between them
+    """p_cam = np.array([0, 0, 0, 1])
+    p_velo0 = np.linalg.inv(data["T_cam0_velo"]).dot(p_cam)
+    p_velo1 = np.linalg.inv(data["T_cam1_velo"]).dot(p_cam)
+    p_velo2 = np.linalg.inv(data["T_cam2_velo"]).dot(p_cam)
+    p_velo3 = np.linalg.inv(data["T_cam3_velo"]).dot(p_cam)
+
+    data["b_gray"] = np.linalg.norm(p_velo1 - p_velo0)  # gray baseline
+    data["b_rgb"] = np.linalg.norm(p_velo3 - p_velo2)  # rgb baseline"""
+
+    return data

--- a/alodataset/utils/kitti.py
+++ b/alodataset/utils/kitti.py
@@ -48,45 +48,21 @@ def load_calib_cam_to_cam(cam_to_cam_filepath, velo_to_cam_file: Union[str, None
         names = ["P0", "P1", "P2", "P3"]
 
     # Create 3x4 projection matrices
-    """P_rect_00 = np.reshape(filedata["P_rect_00"], (3, 4))
-    P_rect_10 = np.reshape(filedata["P_rect_01"], (3, 4))
-    P_rect_20 = np.reshape(filedata["P_rect_02"], (3, 4))
-    P_rect_30 = np.reshape(filedata["P_rect_03"], (3, 4))"""
     p_rect = [np.reshape(filedata[p], (3, 4)) for p in names]
 
-    """data["P_rect_00"] = P_rect_00
-    data["P_rect_10"] = P_rect_10
-    data["P_rect_20"] = P_rect_20
-    data["P_rect_30"] = P_rect_30"""
     for i, p in enumerate(p_rect):
         data[f"P_rect_{i}0"] = p
 
     # Compute the rectified extrinsics from cam0 to camN
-    """T0 = np.eye(4)
-    T0[0, 3] = P_rect_00[0, 3] / P_rect_00[0, 0]
-    T1 = np.eye(4)
-    T1[0, 3] = P_rect_10[0, 3] / P_rect_10[0, 0]
-    T2 = np.eye(4)
-    T2[0, 3] = P_rect_20[0, 3] / P_rect_20[0, 0]
-    T3 = np.eye(4)
-    T3[0, 3] = P_rect_30[0, 3] / P_rect_30[0, 0]"""
-
     rectified_extrinsics = [np.eye(4) for _ in range(4)]
     for i in range(4):
         rectified_extrinsics[i][0, 3] = p_rect[i][0, 3] / p_rect[i][0, 0]
         data[f"T_cam{i}_rect"] = rectified_extrinsics[i]
+
+        # Compute the camera intrinsics
         data[f"K_cam{i}"] = p_rect[i][0:3, 0:3]
 
     # Create 4x4 matrices from the rectifying rotation matrices
-    """R_rect_00 = np.eye(4)
-    R_rect_00[0:3, 0:3] = np.reshape(filedata["R_rect_00"], (3, 3))
-    R_rect_10 = np.eye(4)
-    R_rect_10[0:3, 0:3] = np.reshape(filedata["R_rect_01"], (3, 3))
-    R_rect_20 = np.eye(4)
-    R_rect_20[0:3, 0:3] = np.reshape(filedata["R_rect_02"], (3, 3))
-    R_rect_30 = np.eye(4)
-    R_rect_30[0:3, 0:3] = np.reshape(filedata["R_rect_03"], (3, 3))"""
-
     r_rect = None
     if "R_rect_00" in filedata:
         r_rect = [np.eye(4) for _ in range(4)]
@@ -94,27 +70,16 @@ def load_calib_cam_to_cam(cam_to_cam_filepath, velo_to_cam_file: Union[str, None
             r_rect[i][0:3, 0:3] = np.reshape(filedata["R_rect_0" + str(i)], (3, 3))
             data[f"R_rect_{i}0"] = r_rect[i]
 
-    """data["R_rect_00"] = R_rect_00
-    data["R_rect_10"] = R_rect_10
-    data["R_rect_20"] = R_rect_20
-    data["R_rect_30"] = R_rect_30
-
-    data["T_cam0_rect"] = T0
-    data["T_cam1_rect"] = T1
-    data["T_cam2_rect"] = T2
-    data["T_cam3_rect"] = T3"""
-
     # Load the rigid transformation from velodyne coordinates
     # to unrectified cam0 coordinates
     T_cam0unrect_velo = None
+    stereo_baseline = None
     if velo_to_cam_file is not None and r_rect is not None:
         T_cam0unrect_velo = load_calib_rigid(velo_to_cam_file)
 
         velo_to_cam = [rectified_extrinsics[i].dot(r_rect[i].dot(T_cam0unrect_velo)) for i in range(4)]
         p_cam = np.array([0, 0, 0, 1])
         stereo_baseline = [np.linalg.inv(velo_to_cam[i]).dot(p_cam) for i in range(4)]
-        data["b_gray"] = np.linalg.norm(stereo_baseline[1] - stereo_baseline[0])
-        data["b_rgb"] = np.linalg.norm(stereo_baseline[3] - stereo_baseline[2])
 
         for i in range(4):
             data[f"T_cam{i}_velo"] = velo_to_cam[i]
@@ -129,30 +94,9 @@ def load_calib_cam_to_cam(cam_to_cam_filepath, velo_to_cam_file: Union[str, None
             data[f"T_cam{i}_velo"] = rectified_extrinsics[i].dot(data["T_cam0_velo"])
         p_cam = np.array([0, 0, 0, 1])
         stereo_baseline = [np.linalg.inv(data[f"T_cam{i}_velo"]).dot(p_cam) for i in range(4)]
+
+    if stereo_baseline is not None:
         data["b_gray"] = np.linalg.norm(stereo_baseline[1] - stereo_baseline[0])
         data["b_rgb"] = np.linalg.norm(stereo_baseline[3] - stereo_baseline[2])
-
-    """data["T_cam0_velo"] = T0.dot(R_rect_00.dot(T_cam0unrect_velo))
-    data["T_cam1_velo"] = T1.dot(R_rect_00.dot(T_cam0unrect_velo))
-    data["T_cam2_velo"] = T2.dot(R_rect_00.dot(T_cam0unrect_velo))
-    data["T_cam3_velo"] = T3.dot(R_rect_00.dot(T_cam0unrect_velo))"""
-
-    # Compute the camera intrinsics
-    """data["K_cam0"] = P_rect_00[0:3, 0:3]
-    data["K_cam1"] = P_rect_10[0:3, 0:3]
-    data["K_cam2"] = P_rect_20[0:3, 0:3]
-    data["K_cam3"] = P_rect_30[0:3, 0:3]"""
-
-    # Compute the stereo baselines in meters by projecting the origin of
-    # each camera frame into the velodyne frame and computing the distances
-    # between them
-    """p_cam = np.array([0, 0, 0, 1])
-    p_velo0 = np.linalg.inv(data["T_cam0_velo"]).dot(p_cam)
-    p_velo1 = np.linalg.inv(data["T_cam1_velo"]).dot(p_cam)
-    p_velo2 = np.linalg.inv(data["T_cam2_velo"]).dot(p_cam)
-    p_velo3 = np.linalg.inv(data["T_cam3_velo"]).dot(p_cam)
-
-    data["b_gray"] = np.linalg.norm(p_velo1 - p_velo0)  # gray baseline
-    data["b_rgb"] = np.linalg.norm(p_velo3 - p_velo2)  # rgb baseline"""
 
     return data

--- a/aloscene/mask.py
+++ b/aloscene/mask.py
@@ -14,6 +14,9 @@ from aloscene.labels import Labels
 
 class Mask(aloscene.tensors.SpatialAugmentedTensor):
     """
+    A mask represent which part of the SpatialAugmentedTensor are valid.
+    The value 1 mean invalid and 0 mean valid.
+
     Parameters
     ----------
     x : Union[torch.Tensor, str]

--- a/aloscene/scene_flow.py
+++ b/aloscene/scene_flow.py
@@ -42,10 +42,7 @@ class SceneFlow(aloscene.tensors.SpatialAugmentedTensor):
             self.rename(None)
             .squeeze()
             .permute([1, 2, 0])
-            .detach()
-            .cpu()
-            .contiguous()
-            .numpy()[:, :, [axe_one, axe_two]]
+            .as_numpy()[:, :, [axe_one, axe_two]]
         )
         assert flow.ndim == 3 and flow.shape[-1] == 2, f"wrong flow shape:{flow.shape}"
         flow_color = flow_to_color(flow, clip_flow, convert_to_bgr, magnitude_max) / 255

--- a/aloscene/scene_flow.py
+++ b/aloscene/scene_flow.py
@@ -131,7 +131,7 @@ class SceneFlow(aloscene.tensors.SpatialAugmentedTensor):
             names=("B", "C", "H", "W") if has_batch else ("C", "H", "W"),
             occlusion=None
             if occlusion is None
-            else Mask(occlusion, names=("B", "H", "W") if has_batch else ("H", "W")),
+            else Mask(occlusion, names=("B", "C", "H", "W") if has_batch else ("C", "H", "W")),
         )
         return tensor
 

--- a/aloscene/scene_flow.py
+++ b/aloscene/scene_flow.py
@@ -122,7 +122,7 @@ class SceneFlow(aloscene.tensors.SpatialAugmentedTensor):
             if depth.occlusion is not None:
                 occlusion = occlusion | depth.occlusion.as_tensor().bool()
             if next_depth.occlusion is not None:
-                next_depth_tensor = next_depth.occlusion.as_tensor().bool().unsqueeze(1)
+                next_depth_tensor = next_depth.occlusion.as_tensor().bool()
 
                 # Use of 'not' needed because the grid_sample has padding_mode="zeros" and
                 # the 0 from this function mean that the pixel is occluded
@@ -137,7 +137,6 @@ class SceneFlow(aloscene.tensors.SpatialAugmentedTensor):
                 moved_occlusion = ~(moved_occlusion >= 0.99999)
 
                 # Fusion of the 2 occlusion mask
-                moved_occlusion = moved_occlusion.squeeze(1)
                 occlusion = occlusion | moved_occlusion
 
         # Remove the artificial batch dimension

--- a/aloscene/tensors/augmented_tensor.py
+++ b/aloscene/tensors/augmented_tensor.py
@@ -48,10 +48,6 @@ class AugmentedTensor(torch.Tensor):
     def __init__(self, x, **kwargs):
         super().__init__()
 
-    @classmethod
-    def dummy(cls, size: tuple):
-        return cls(torch.ones(size))
-
     def drop_children(self):
         """Remove all children from this augmented tensor and return
         the removed children.

--- a/aloscene/tensors/augmented_tensor.py
+++ b/aloscene/tensors/augmented_tensor.py
@@ -48,6 +48,10 @@ class AugmentedTensor(torch.Tensor):
     def __init__(self, x, **kwargs):
         super().__init__()
 
+    @classmethod
+    def dummy(cls, size: tuple):
+        return cls(torch.ones(size))
+
     def drop_children(self):
         """Remove all children from this augmented tensor and return
         the removed children.

--- a/aloscene/tensors/spatial_augmented_tensor.py
+++ b/aloscene/tensors/spatial_augmented_tensor.py
@@ -28,6 +28,8 @@ class SpatialAugmentedTensor(AugmentedTensor):
         If part of a stereo setup, will encode the side of the camere "left" or "right" or None.
     baseline: float | None
         If part of a stereo setup, the `baseline` is the distance between the two cameras.
+    timestamp: float | None
+        Time in seconds since the beginning of the sequence.
     """
 
     @staticmethod
@@ -52,6 +54,7 @@ class SpatialAugmentedTensor(AugmentedTensor):
         tensor.add_property("camera_side", camera_side)
         tensor.add_property("projection", projection)
         tensor.add_property("distortion", distortion)
+        tensor.add_property("timestamp", None)
 
         # Intrisic and extrinsic parameters are cloned by default, to prevent having multiple reference
         # of the same intrisic/extrinsic across nodes.

--- a/aloscene/tensors/spatial_augmented_tensor.py
+++ b/aloscene/tensors/spatial_augmented_tensor.py
@@ -65,6 +65,16 @@ class SpatialAugmentedTensor(AugmentedTensor):
     def __init__(self, x, *args, **kwargs):
         super().__init__(x)
 
+    @classmethod
+    def dummy(cls, size: tuple, names: tuple):
+        dummy_class = cls(torch.ones(size))
+        mask_size = list(size)
+        if 'C' in names:
+            mask_size[names.index('C')] = 1
+        mask_size = tuple(mask_size)
+        dummy_class.append_mask(aloscene.Mask(torch.ones(mask_size), names=names))
+        return dummy_class
+
     @property
     def HW(self):
         return (self.H, self.W)

--- a/aloscene/tensors/spatial_augmented_tensor.py
+++ b/aloscene/tensors/spatial_augmented_tensor.py
@@ -3,6 +3,7 @@ import math
 import torchvision.transforms.functional as F
 from torchvision.transforms import InterpolationMode
 import torch
+from typing import Union
 
 from aloscene.renderer import View, Renderer
 from .augmented_tensor import AugmentedTensor
@@ -34,11 +35,11 @@ class SpatialAugmentedTensor(AugmentedTensor):
         cls,
         x,
         *args,
-        cam_intrinsic: CameraIntrinsic = None,
-        cam_extrinsic: CameraExtrinsic = None,
+        cam_intrinsic: Union[CameraIntrinsic, None] = None,
+        cam_extrinsic: Union[CameraExtrinsic, None] = None,
         # For stereo setups
-        camera_side: str = None,
-        baseline: float = None,
+        camera_side: Union[str, None] = None,
+        baseline: Union[float, None] = None,
         mask=None,
         projection="pinhole",
         distortion=1.0,
@@ -76,8 +77,9 @@ class SpatialAugmentedTensor(AugmentedTensor):
     def H(self):
         return self.shape[self.names.index("H")]
 
-    def append_mask(self, mask, name: str = None):
+    def append_mask(self, mask, name: Union[str, None] = None):
         """Attach a mask to the frame.
+        The value 1 mean invalid and 0 mean valid.
 
         Parameters
         ----------


### PR DESCRIPTION
Kitti Dataset (Stereo, Flow, Scene Flow, Depth, Odometry, Object, Tracking, Road, Semantics)

* ***Kitti Depth*** : How to use Kitti Depth
```python
date = "2011_09_26"
idsOfDrives = [
    "0001",  # sample from training subset
    "0002",  # sample from validation subset
]
custom_drives = {date: idsOfDrives}
kitti_ds = KittiDepth(
    subset="all",
    return_depth=True,
    custom_drives=custom_drives,
)

for f, frames in enumerate(kitti_ds.train_loader(batch_size=2)):
    frames = Frame.batch_list(frames)
```

* ***Kitti Semantic*** : The semantic class
```python
dataset = KittiSemanticDataset()
obj = dataset.getitem(0)
obj.get_view().render()
```

* ***How to use the remaining task of the dataset*** : Dataset's class list : `KittiStereoFlow2012`, `KittiStereoFlowSFlow2015`, `KittiOdometryDataset`, `KittiObjectDataset`, `KittiTrackingDataset`, `KittiRoadDataset`
```python
dataset = DATASET_CLASS(right_frame=False)
obj = dataset.getitem(0)
obj["left"].get_view().render()
```

* ***Scene Flow: dimensions*** : Error with shape of occlusion mask.

_____
This pull request includes

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update