### PR TITLE
Support for the kumler_bauer projection in coords2rtheta

### DIFF
--- a/aloscene/utils/depth_utils.py
+++ b/aloscene/utils/depth_utils.py
@@ -47,8 +47,7 @@ def coords2rtheta(
         theta = r_d / (focal * distortion)
     elif projection == "kumler_bauer":
         assert isinstance(distortion, Sequence), "Kumler-Bauer projection needs two distortion coefficients (alpha, beta)"
-        theta_dist = torch.atan(r_d / focal)
-        theta = torch.atan((distortion[0] / focal) * torch.sin(distortion[1] * theta_dist))
+        theta = torch.arcsin(distortion[0] * r_d / focal) / distortion[1]
     else:
         raise NotImplementedError
 

--- a/aloscene/utils/depth_utils.py
+++ b/aloscene/utils/depth_utils.py
@@ -43,10 +43,10 @@ def coords2rtheta(
     if projection == "pinhole":
         theta = torch.atan(r_d / focal)
     elif projection == "equidistant":
-        assert not isinstance(distortion, Sequence)
+        assert isinstance(distortion, (float, int))
         theta = r_d / (focal * distortion)
     elif projection == "kumler_bauer":
-        assert isinstance(distortion, Sequence), "Kumler-Bauer projection needs two distortion coefficients (alpha, beta)"
+        assert isinstance(distortion, Sequence) and len(distortion) == 2, "Kumler-Bauer projection needs two distortion coefficients (alpha, beta)"
         theta = torch.arcsin(distortion[0] * r_d / focal) / distortion[1]
     else:
         raise NotImplementedError

--- a/aloscene/utils/depth_utils.py
+++ b/aloscene/utils/depth_utils.py
@@ -1,5 +1,5 @@
 from aloscene.tensors import AugmentedTensor
-from typing import Union, Tuple
+from typing import Union, Tuple, Sequence
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -45,10 +45,9 @@ def coords2rtheta(
     elif projection == "equidistant":
         theta = r_d / (focal * distortion)
     elif projection == "kumler_bauer":
-        if isinstance(distortion, tuple):
-            theta = torch.asin(r_d / (distortion[0] * focal)) / distortion[1]
-        else:  # use the same value for k1 & k2
-            theta = torch.asin(r_d / (distortion * focal)) / distortion
+        assert isinstance(distortion, Sequence), "Kumler-Bauer projection needs two distortion coefficients (alpha, beta)"
+        theta_dist = torch.atan(r_d / focal)
+        theta = torch.atan((distortion[0] / focal) * torch.sin(distortion[1] * theta_dist))
     else:
         raise NotImplementedError
 

--- a/aloscene/utils/depth_utils.py
+++ b/aloscene/utils/depth_utils.py
@@ -43,6 +43,7 @@ def coords2rtheta(
     if projection == "pinhole":
         theta = torch.atan(r_d / focal)
     elif projection == "equidistant":
+        assert not isinstance(distortion, Sequence)
         theta = r_d / (focal * distortion)
     elif projection == "kumler_bauer":
         assert isinstance(distortion, Sequence), "Kumler-Bauer projection needs two distortion coefficients (alpha, beta)"

--- a/aloscene/utils/depth_utils.py
+++ b/aloscene/utils/depth_utils.py
@@ -46,8 +46,10 @@ def coords2rtheta(
         assert isinstance(distortion, (float, int))
         theta = r_d / (focal * distortion)
     elif projection == "kumler_bauer":
+        # distortion [k1, k2, focal_meter]
         assert isinstance(distortion, Sequence) and len(distortion) == 2, "Kumler-Bauer projection needs two distortion coefficients (alpha, beta)"
-        theta = torch.arcsin(distortion[0] * r_d / focal) / distortion[1]
+        fm = distortion[2]
+        theta = torch.arcsin(fm / distortion[0] * r_d / focal) / distortion[1]
     else:
         raise NotImplementedError
 


### PR DESCRIPTION
Support for the kumler_bauer projection in coords2rtheta

* ***New feature 1*** : 
```py
coords2rtheta(..., distortion=(0.25, 0.45), projection="kumler_bauer")
```
```py
coords2rtheta(..., distortion=0.25, projection="equidistant") # API doesn't change for other projections
```

_____
This pull request includes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
