### PR TITLE
better handle distortion coef

### DIFF
--- a/aloscene/depth.py
+++ b/aloscene/depth.py
@@ -3,6 +3,7 @@ from shutil import ExecError
 import matplotlib
 from matplotlib.pyplot import sca
 import torch
+from typing import *
 import warnings
 import aloscene
 from aloscene import Mask
@@ -287,7 +288,8 @@ class Depth(aloscene.tensors.SpatialAugmentedTensor):
             r = torch.tan(theta)
 
             if projection == "equidistant":
-                focal_length = focal_length * theta * distortion / r.abs()
+                dist_coef = distortion[0] if isinstance(distortion, Sequence) else distortion
+                focal_length = focal_length * theta * dist_coef / r.abs()
             elif projection == "kumler_bauer":
                 focal_length = (
                     distortion[0] * torch.sin(distortion[1] * theta) * focal_length / (distortion[2] * r.abs())

--- a/aloscene/utils/depth_utils.py
+++ b/aloscene/utils/depth_utils.py
@@ -40,13 +40,13 @@ def coords2rtheta(
     if projection == "pinhole":
         theta = torch.atan(r_d / focal)
     elif projection == "equidistant":
-        assert isinstance(distortion, (float, int))
-        theta = r_d / (focal * distortion)
+        dist_coef = distortion[0] if isinstance(distortion, Sequence) else distortion
+        theta = r_d / (focal * dist_coef)
     elif projection == "kumler_bauer":
         # distortion [k1, k2, focal_meter]
         assert (
             isinstance(distortion, Sequence) and len(distortion) == 3
-        ), "Kumler-Bauer projection needs two distortion coefficients (alpha, beta)"
+        ), "Kumler-Bauer projection needs 3 distortion coefficients (alpha, beta, focal in meter)"
         fm = distortion[2]
         theta = torch.arcsin(fm / distortion[0] * r_d / focal) / distortion[1]
     else:


### PR DESCRIPTION
* ***New feature 1*** : Better handle distortion coef for equidistant projection: both `float` and `list` are accepted.
```python
# Python code snippet showing how to use it.
import torch
from aloscene import Depth

x = torch.rand(size=(1, 1, 20, 20))
depth1 = Depth(x, projection="equidistant", distortion=[0.5])
depth2 = Depth(x, projection="equidistant", distortion=0.5)
```

_____
This pull request includes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
