### PR TITLE
alobugdays/241-aten-w-mergeable-properties

### DIFF
--- a/aloscene/bounding_boxes_2d.py
+++ b/aloscene/bounding_boxes_2d.py
@@ -33,7 +33,7 @@ class BoundingBoxes2D(aloscene.tensors.AugmentedTensor):
     x: list | torch.Tensor | np.array
         BoundingBoxes2D data. See explanation above for details.
     boxes_format: str
-        One of `xyxy` (y_min, x_min, y_max, x_max), `yxyx` (x_min, y_min, x_max, y_max) or `xcyc` (xc, yc, width,
+        One of `xyxy` (x_min, y_min, x_max, y_max), `yxyx` (y_min, x_min, y_max, x_max) or `xcyc` (xc, yc, width,
         height)
     absolute: bool
         Whether your boxes are encoded as absolute value or relative values (between 0 and 1). If absolute is True,


### PR DESCRIPTION
Merge augmented tensors properties into lists instead of throwing assertion errors.
Fix issue #241 

`_merge_tensor`'s behavior is unchanged when the properties are the same.


### Example when using `torch.cat((a, b, c), dim=0)` with a, b, c being tensors with DIFFERENT projection properties
Before:
```sh
AssertionError: Trying to merge augmented tensor with different property: projection
```
After:
```python
tensor(
	projection=['kumler_bauer', 'equidistant', 'pinhole']
	normalization=minmax_sym
	pose=torch.Size([3, 4, 4])
	mask=torch.Size([3, 1, H, W])
	depth=torch.Size([3, 1, H, W])
	cam_intrinsic=torch.Size([3, 4, 4])
	cam_extrinsic=torch.Size([3, 4, 4])
	distortion=[[0.45, 0.39, 0.12], 0.25, 1.0]
        ...
```

### Example when using `torch.cat((a, b, c), dim=0)` with a, b, c being tensors with SAME projection properties
Before and after (the behavior is unchanged):
```python
tensor(
	projection=kumler_bauer
	normalization=minmax_sym
	pose=torch.Size([3, 4, 4])
	mask=torch.Size([3, 1, H, W])
	depth=torch.Size([3, 1, H, W])
	cam_intrinsic=torch.Size([3, 4, 4])
	cam_extrinsic=torch.Size([3, 4, 4])
	distortion=[0.45, 0.39, 0.12]
        ...
```
_____
This pull request includes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
