### PR TITLE
alobugdays/67-resnet-mean-std-norm-at-instantiation

### DIFF
--- a/aloscene/frame.py
+++ b/aloscene/frame.py
@@ -129,6 +129,7 @@ class Frame(aloscene.tensors.SpatialAugmentedTensor):
         tensor.add_child("scene_flow", labels, align_dim=["B", "T"], mergeable=False)
 
         # Add other tensor property
+        assert normalization in {"01", "255", "minmax_sym", "resnet"}, f"{normalization} norm is not yet supported"
         tensor.add_property("normalization", normalization)
         tensor.add_property("_resnet_mean_std", ((0.485, 0.456, 0.406), (0.229, 0.224, 0.225)))
         tensor.add_property("mean_std", mean_std)

--- a/aloscene/frame.py
+++ b/aloscene/frame.py
@@ -131,8 +131,13 @@ class Frame(aloscene.tensors.SpatialAugmentedTensor):
         # Add other tensor property
         assert normalization in {"01", "255", "minmax_sym", "resnet"}, f"{normalization} norm is not yet supported"
         tensor.add_property("normalization", normalization)
-        tensor.add_property("_resnet_mean_std", ((0.485, 0.456, 0.406), (0.229, 0.224, 0.225)))
-        tensor.add_property("mean_std", mean_std)
+
+        resnet_rgb_mean_std = ((0.485, 0.456, 0.406), (0.229, 0.224, 0.225))
+        tensor.add_property("_resnet_mean_std", resnet_rgb_mean_std)
+        if normalization == "resnet":
+            tensor.add_property("mean_std", resnet_rgb_mean_std)
+        else:
+            tensor.add_property("mean_std", mean_std)
 
         return tensor
 


### PR DESCRIPTION
- Check if the requested normalization is supported
- Set the `mean_std` property to `resnet_rgb_mean_std` at instantiation when using `normalization="resnet"`

closes issue #67 

_____
This pull request includes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
