### PR TITLE
Alobugdays : added warning message for labels_set

### DIFF
--- a/alodataset/coco_detection_dataset.py
+++ b/alodataset/coco_detection_dataset.py
@@ -219,6 +219,6 @@ if __name__ == "__main__":
     coco_dataset = CocoDetectionDataset(split=Split.VAL, return_multiple_labels=True)
     for f, frames in enumerate(coco_dataset.stream_loader(num_workers=1)):
         frames = Frame.batch_list([frames])
-        frames.get_view().render()
+        frames.get_view(labels_set="category").render()
         if f > 1:
             break

--- a/aloscene/bounding_boxes_2d.py
+++ b/aloscene/bounding_boxes_2d.py
@@ -445,6 +445,10 @@ class BoundingBoxes2D(aloscene.tensors.AugmentedTensor):
         """
         from aloscene import Frame
 
+        if isinstance(self.labels, dict):
+            if len(self.labels.keys())!=0:
+                print("You can select a labels set and pass it to frame.get_view(). Available labels set are: ", [key for key in self.labels.keys()])
+
         if frame is not None:
             if len(frame.shape) > 3:
                 raise Exception(f"Expect image of shape c,h,w. Found image with shape {frame.shape}")
@@ -586,8 +590,7 @@ class BoundingBoxes2D(aloscene.tensors.AugmentedTensor):
             assert (boxes1.as_tensor()[:, 2:] >= boxes1.as_tensor()[:, :2]).all(), f"{boxes1.as_tensor()}"
             assert (boxes2.as_tensor()[:, 2:] >= boxes2.as_tensor()[:, :2]).all(), f"{boxes2.as_tensor()}"
         except:
-            print("boxes1", boxes1)
-            print("boxes2", boxes2)
+
             assert (boxes1.as_tensor()[:, 2:] >= boxes1.as_tensor()[:, :2]).all(), f"{boxes1.as_tensor()}"
             assert (boxes2.as_tensor()[:, 2:] >= boxes2.as_tensor()[:, :2]).all(), f"{boxes2.as_tensor()}"
 


### PR DESCRIPTION
Solves issue #121 
The fix is actually quite simple, you just need to call 
`frames.get_view(labels_set=NAME_OF_YOUR_LABELS_SET).render()`

instead of 
`frames.get_view().render()
`
I added an explanatory messages to BoundingBoxes2d.get_view() with the available labels so the user finds the solution more easily