### PR TITLE
load model from run_id

### DIFF
--- a/alonet/common/weights.py
+++ b/alonet/common/weights.py
@@ -32,7 +32,8 @@ WEIGHT_NAME_TO_FILES = {
 
 
 def load_weights(
-        model, weights=None,
+        model,
+        weights=None,
         run_id=None,
         project_run_id=None,
         checkpoint="best",
@@ -51,7 +52,7 @@ def load_weights(
     device: torch.device
         Device to load the weights into
     """
-    assert not (run_id is None and weights is None), "run_id or weights must be set."
+    assert run_id is not None or weights is not None, "run_id or weights must be set."
 
     if weights is None:
         if project_run_id is None:
@@ -77,8 +78,7 @@ def load_weights(
         model.load_state_dict(checkpoint, strict=strict_load_weights)
         print(f"Weights loaded from {weights}")
     elif weights in WEIGHT_NAME_TO_FILES:
-        weights_dir = os.path.join(vb_folder(create_if_not_found=True), "weights")
-        weights_dir = os.path.join(weights_dir, weights)
+        weights_dir = os.path.join(vb_folder(create_if_not_found=True), "weights", weights)
         if not os.path.exists(weights_dir):
             os.makedirs(weights_dir)
         for f in WEIGHT_NAME_TO_FILES[weights]:

--- a/alonet/common/weights.py
+++ b/alonet/common/weights.py
@@ -1,7 +1,7 @@
 import torch
 import requests
 import os
-from alonet.common.pl_helpers import vb_folder
+from alonet.common.pl_helpers import vb_folder, checkpoint_handler
 
 WEIGHT_NAME_TO_FILES = {
     "detr-r50": ["https://storage.googleapis.com/visualbehavior-publicweights/detr-r50/detr-r50.pth"],
@@ -31,7 +31,15 @@ WEIGHT_NAME_TO_FILES = {
 }
 
 
-def load_weights(model, weights, device, strict_load_weights=True):
+def load_weights(
+        model, weights=None,
+        run_id=None,
+        project_run_id=None,
+        checkpoint="best",
+        monitor="val_loss",
+        device=torch.device("cpu"),
+        strict_load_weights=True,
+    ):
     """Load and/or download weights from public cloud
 
     Parameters
@@ -43,10 +51,19 @@ def load_weights(model, weights, device, strict_load_weights=True):
     device: torch.device
         Device to load the weights into
     """
-    weights_dir = os.path.join(vb_folder(), "weights")
+    assert not (run_id is None and weights is None), "run_id or weights must be set."
 
-    if not os.path.exists(weights_dir):
-        os.makedirs(weights_dir)
+    if weights is None:
+        if project_run_id is None:
+            Exception(
+                "project_run_id need to be set if we load model from run_id."
+            )
+        run_id_project_dir = os.path.join(vb_folder(), f"project_{project_run_id}", run_id)
+        ckpt_path = checkpoint_handler(checkpoint, run_id_project_dir, monitor)
+        weights = os.path.join(run_id_project_dir, ckpt_path)
+        if not os.path.exists(weights):
+            raise Exception(f"Impossible to load the ckpt at the following destination:{weights}")
+        print(f"Loading ckpt from {run_id} at {weights}")
 
     if os.path.splitext(weights.lower())[1] == ".pth":
         checkpoint = torch.load(weights, map_location=device)
@@ -60,6 +77,7 @@ def load_weights(model, weights, device, strict_load_weights=True):
         model.load_state_dict(checkpoint, strict=strict_load_weights)
         print(f"Weights loaded from {weights}")
     elif weights in WEIGHT_NAME_TO_FILES:
+        weights_dir = os.path.join(vb_folder(create_if_not_found=True), "weights")
         weights_dir = os.path.join(weights_dir, weights)
         if not os.path.exists(weights_dir):
             os.makedirs(weights_dir)


### PR DESCRIPTION
General description of your pull request with the list of new features and/or bugs.

* ***New feature 1 #85 *** : Now we can load a model directly from `run_id` without passing `load_training` and Lightning module.
* `weights` has highest priority. if `weights is None`, load model from `run_id` is used.
* We can choose to load best checkpoint or last checkpoint.
```python
from alonet.common.weights import load_weights
from alonet.detr import DetrR50

model = DetrR50(num_classes=91, weights="detr-r50")

# load from downloaded weight
load_weights(model, weights="detr-r50")

# load from .pth file
load_weights(model, weights="~/.aloception/weights/detr-r50/detr-r50.pth")


# load from run_id
load_weights(model, run_id="your_run_id_heer", project_run_id="your_project_run_id",)
```

_____
This pull request includes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
