### PR TITLE
221 named labels on boundingboxes2d dont render

### DIFF
--- a/aloscene/bounding_boxes_2d.py
+++ b/aloscene/bounding_boxes_2d.py
@@ -469,10 +469,11 @@ class BoundingBoxes2D(aloscene.tensors.AugmentedTensor):
         if isinstance(boxes_abs.labels, aloscene.Labels):
             labels = boxes_abs.labels
         elif isinstance(boxes_abs.labels, dict):
+            labels = []
             for k, v in boxes_abs.labels.items():
                 if isinstance(v, aloscene.Labels):
-                    labels = v
-                    break
+                    labels.append(v)
+            labels = [labels] * len(boxes_abs)
         else:
             labels = [None] * len(boxes_abs)
         if labels_set is not None and not isinstance(boxes_abs.labels, dict):
@@ -494,11 +495,24 @@ class BoundingBoxes2D(aloscene.tensors.AugmentedTensor):
             x1, y1, x2, y2 = box.as_tensor()
 
             if label is not None:
-                color = self._GLOBAL_COLOR_SET[int(label) % len(self._GLOBAL_COLOR_SET)]
-                text = label.labels_names[int(label)] if label.labels_names else int(label)
-                cv2.putText(
-                    frame, str(text), (int(x2), int(y1)), cv2.FONT_HERSHEY_SIMPLEX, 0.5, color, 1, cv2.LINE_AA
-                )
+                print("label", label)
+                if isinstance(label, list):
+                    label_sum = sum([int(label_value[b]) for label_value in label])
+                    color = self._GLOBAL_COLOR_SET[int(label_sum) % len(self._GLOBAL_COLOR_SET)]
+                    text = []
+                    for label_elm in label:
+                        text.append(
+                            str(
+                                label_elm.labels_names[int(label_elm[b])]
+                                if label_elm.labels_names
+                                else int(label_elm[b])
+                            )
+                        )
+                    text = ", ".join(text)
+                else:
+                    color = self._GLOBAL_COLOR_SET[int(label) % len(self._GLOBAL_COLOR_SET)]
+                    text = label.labels_names[int(label)] if label.labels_names else int(label)
+                cv2.putText(frame, str(text), (int(x2), int(y1)), cv2.FONT_HERSHEY_SIMPLEX, 0.5, color, 1, cv2.LINE_AA)
                 cv2.rectangle(frame, (int(x1), int(y1)), (int(x2), int(y2)), color, 3)
             else:
                 color = (0, 1, 0)

--- a/aloscene/bounding_boxes_2d.py
+++ b/aloscene/bounding_boxes_2d.py
@@ -466,7 +466,15 @@ class BoundingBoxes2D(aloscene.tensors.AugmentedTensor):
         # Draw bouding boxes
 
         # Try to retrieve the associated label ID (if any)
-        labels = boxes_abs.labels if isinstance(boxes_abs.labels, aloscene.Labels) else [None] * len(boxes_abs)
+        if isinstance(boxes_abs.labels, aloscene.Labels):
+            labels = boxes_abs.labels
+        elif isinstance(boxes_abs.labels, dict):
+            for k, v in boxes_abs.labels.items():
+                if isinstance(v, aloscene.Labels):
+                    labels = v
+                    break
+        else:
+            labels = [None] * len(boxes_abs)
         if labels_set is not None and not isinstance(boxes_abs.labels, dict):
             raise Exception(
                 f"Trying to display a boxes labels set ({labels_set}) while boxes do not have multiple set of labels"


### PR DESCRIPTION
All the named labels are displayed next to BoundingBoxes2D

* ***Labels BoundingBoxes2D*** : Render Labels next to BoundingBoxes2D FIX #221 
```python
import numpy as np
from aloscene import Frame, BoundingBoxes2D, Labels

frame = Frame(np.zeros((3, 100, 500)), normalization="01")
label = Labels([0, 1, 0])
label2 = Labels([0, 0, 1], labels_names=["red", "green"])
box = BoundingBoxes2D([[100, 20, 400, 80], [200, 40, 400, 80], [100, 40, 300, 80]], boxes_format="xyxy", absolute=True, frame_size=frame.HW)

box.append_labels(label, name="label")
box.append_labels(label2, name="label2")

frame.append_boxes2d(box)

print(box)
frame.get_view().render()
```
_____
This pull request includes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
