### PR TITLE
Issue: #240 fixed (BoundingBoxes3D don't render correctly with padded images)

### DIFF
--- a/alodataset/__init__.py
+++ b/alodataset/__init__.py
@@ -14,5 +14,6 @@ from .crowd_human_dataset import CrowdHumanDataset
 from .sintel_flow_dataset import SintelFlowDataset
 from .sintel_disparity_dataset import SintelDisparityDataset
 from .sintel_multi_dataset import SintelMultiDataset
+from .from_directory_dataset import FromDirectoryDataset
 from .woodScape_dataset import WooodScapeDataset
 from .woodScape_split_dataset import WoodScapeSplitDataset

--- a/alodataset/base_dataset.py
+++ b/alodataset/base_dataset.py
@@ -56,7 +56,7 @@ def stream_loader(dataset, num_workers=2):
     return data_loader
 
 
-def train_loader(dataset, batch_size=1, num_workers=2, sampler=torch.utils.data.RandomSampler):
+def train_loader(dataset, batch_size=1, num_workers=2, sampler=torch.utils.data.RandomSampler, sampler_kwargs={}):
     """Get training loader from the dataset
 
     Parameters
@@ -69,14 +69,15 @@ def train_loader(dataset, batch_size=1, num_workers=2, sampler=torch.utils.data.
         Number of workers, by default 2
     sampler : torch.utils.data, optional
         Callback to sampler the dataset, by default torch.utils.data.RandomSampler
+        Or instance of any class inheriting from torch.utils.data.Sampler
 
     Returns
     -------
     torch.utils.data.DataLoader
         A generator
     """
-    sampler = sampler(dataset) if sampler is not None else None
-
+    if sampler is not None and not(isinstance(sampler, torch.utils.data.Sampler)):
+        sampler = sampler(dataset, **sampler_kwargs)
     data_loader = torch.utils.data.DataLoader(
         dataset,
         # batch_sampler=batch_sampler,
@@ -332,7 +333,7 @@ class BaseDataset(torch.utils.data.Dataset):
         """
         return stream_loader(self, num_workers=num_workers)
 
-    def train_loader(self, batch_size=1, num_workers=2, sampler=torch.utils.data.RandomSampler):
+    def train_loader(self, batch_size=1, num_workers=2, sampler=torch.utils.data.RandomSampler, sampler_kwargs={}):
         """Get training loader from the dataset
 
         Parameters
@@ -351,7 +352,7 @@ class BaseDataset(torch.utils.data.Dataset):
         torch.utils.data.DataLoader
             A generator
         """
-        return train_loader(self, batch_size=batch_size, num_workers=num_workers, sampler=sampler)
+        return train_loader(self, batch_size=batch_size, num_workers=num_workers, sampler=sampler, sampler_kwargs=sampler_kwargs    )
 
     def prepare(self):
         """Prepare the dataset. Not all child class need to implement this method.

--- a/alodataset/coco_base_dataset.py
+++ b/alodataset/coco_base_dataset.py
@@ -13,7 +13,7 @@ from typing import Dict, Union
 
 from alodataset import BaseDataset
 from aloscene import BoundingBoxes2D, Frame, Labels, Mask
-
+from pathlib import Path
 
 class CocoBaseDataset(BaseDataset):
     """
@@ -78,10 +78,17 @@ class CocoBaseDataset(BaseDataset):
             return
         else:
             assert img_folder is not None, "When sample = False, img_folder must be given."
-            assert ann_file is not None, "When sample = False, ann_file must be given."
+            assert ann_file is not None or  "test"  in img_folder, "When sample = False and the test split is not used, ann_file must be given."
+
 
         # Create properties
         self.img_folder = os.path.join(self.dataset_dir, img_folder)
+
+        if "test" in img_folder:
+            #get a list of  indices that don't rely on the annotation file
+            self.items= list(sorted([int(Path(os.path.join(self.img_folder, f)).stem) for f in os.listdir(self.img_folder) if os.path.isfile(os.path.join(self.img_folder, f))]))
+            return
+
         self.coco = COCO(os.path.join(self.dataset_dir, ann_file))
         self.items = list(sorted(self.coco.imgs.keys()))
 
@@ -231,7 +238,14 @@ class CocoBaseDataset(BaseDataset):
             return BaseDataset.__getitem__(self, idx)
 
         image_id = self.items[idx]
+        if "test" in self.img_folder:
+            #get the filename from image_id without relying on annotation file
+            frame = Frame(os.path.join(self.img_folder, f"{str(image_id).zfill(12)}.jpg"))
+
+            return frame
+
         frame = Frame(os.path.join(self.img_folder, self.coco.loadImgs(image_id)[0]["file_name"]))
+
         target = self.coco.loadAnns(self.coco.getAnnIds(image_id))
         target = {"image_id": image_id, "annotations": target}
         _, target = self.prepare(frame, target)
@@ -341,7 +355,12 @@ class ConvertCocoPolysToMask(object):
 
 
 if __name__ == "__main__":
-    coco_dataset = CocoBaseDataset(sample=True)
+    coco_dataset = CocoBaseDataset(sample=False, img_folder="test2017")
+    #checking if regular getitem works
+    stuff=coco_dataset.getitem(0)
+    stuff.get_view().render()
+
+    #check if dataloader works
     for f, frames in enumerate(coco_dataset.train_loader(batch_size=2)):
         frames = Frame.batch_list(frames)
         frames.get_view().render()

--- a/alodataset/from_directory_dataset.py
+++ b/alodataset/from_directory_dataset.py
@@ -1,0 +1,153 @@
+import aloscene
+from alodataset import BaseDataset
+
+import os
+import cv2
+import glob
+import numpy as np
+from typing import List, Union, Dict
+
+
+class FromDirectoryDataset(BaseDataset):
+    """Data iterator from directory 
+    
+    Parameters
+    ----------
+        dirs : List[str]
+            List of directories paths to load images from. Default None.
+        
+        slice : List[flaot]
+            Use for restrciting the number of samples. Default [0, 1].
+                Example slice = [0.2, 0.4] will only load samples from 20%th to 40%th.
+
+    Raises
+    ------
+        Exception
+            All directories are empty.
+
+        Exception
+            One of the directories does not exist.
+
+        Exception
+            One of the paths is not a directory.
+
+    Examples
+    --------
+        >>> # from list of paths.
+        >>> path1 = "/PATH/TO/DATA/DIR1"
+        >>> path2 = "/PATH/TO/DATA/DIR2"
+
+        >>> data = FromDirectoryDataset(dirs=[path1, path2])
+        >>> for i in range(len(data)):
+        >>>    print(data[i].shape)
+
+        >>> # from dict of list of paths.
+        >>> path0 = "/PATH/TO/DATA/DIR0"
+        >>> path1 = "/PATH/TO/DATA/DIR1"
+        >>> path2 = "/PATH/TO/DATA/DIR2"
+        >>> path3 = "/PATH/TO/DATA/DIR3"
+
+        >>> data = FromDirectoryDataset(dirs={"key1": [path0, path1], "key2": [path2, path3]])
+        >>> for i in range(len(data)):
+        >>>    print(data[i]["key1"].shape)
+        >>>    print(data[i]["key2"].shape)
+
+    """
+    def __init__(
+            self,
+            dirs : Union[List[str], Dict] = None,
+            slice : list = [0, 1],
+            name : str = "from_dir",
+            **kwargs
+            ):
+        super().__init__(
+            name,
+            **kwargs
+            )
+        assert not self.sample, "Can not sample this dataset"
+        assert dirs not in [None, [], {}], "List of directories not provided"
+    
+        assert len(slice) == 2, "Slice arg should be a list of 2 elements"
+        assert slice[0] < slice[1], "Element at index 1 should be greater than elemnt at index 0."
+        assert slice[0] >= 0 and slice[1] <=1, "Unvalid slice, values should be between 0 and 1"
+
+        if isinstance(dirs , list):
+            self.items = self._extract_dir_path(dirs)
+            
+        elif isinstance(dirs, dict):
+            titems = []
+            keys = list(dirs.keys())
+            for key in keys:
+                p_list = dirs[key]
+                d_path = {key: self._extract_dir_path(p_list)}
+                titems.append(d_path)
+            # Hypotesis : all dirs have the same number of elements
+            for i in range(len(titems[0][keys[0]])):
+                sample = {}
+                for key in keys:
+                    sample[key] = titems[keys.index(key)][key][i]
+                self.items.append(sample)
+
+        # Slicing
+        length = len(self.items)
+        end = int(length * slice[1])
+        start = int(length * slice[0])
+        self.items = self.items[start:end]
+
+        # Samples check.
+        if not len(self.items):
+            raise Exception("Empty dir, no .png .jpg files found")
+
+    def _extract_dir_path(self, dirs):
+        items = []
+        for dir in dirs:
+            if not os.path.exists(dir):
+                raise Exception(f"Directory not found: {dir}")
+            if not os.path.isdir(dir):
+                raise Exception(f"{dir} is not a directory")
+        
+        for dir in dirs:
+            gpath = os.path.join(dir, "*")
+            files = sorted(glob.glob(gpath))
+            files = list(filter(self._filter_img_path, files))
+            items += files
+        return items
+    
+    @staticmethod
+    def _filter_img_path(path):
+        ends = (".png", ".jpg")
+        return path.endswith(ends)
+    
+    @staticmethod
+    def _load_frame(path):
+        if path.endswith((".png", ".jpg")):
+            frame = cv2.imread(path)
+            frame = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
+            frame = np.moveaxis(frame, 2, 0)
+            frame = aloscene.Frame(frame, names=tuple("CHW"))
+            return frame
+        else:
+            raise Exception(f"Unknown extention for file {path}")
+
+    def getitem(self, idx):
+        item = self.items[idx]
+        if isinstance(item, str):
+            frame = self._load_frame(item)
+        elif isinstance(item, dict):
+            frame = {k: self._load_frame(path) for k, path in item.items()}
+        else:
+            raise Exception("Unknown item format")
+        return frame
+    
+    def set_dataset_dir(self, dataset_dir: str):
+        """Override parent function, this class has no dir"""
+        pass
+
+
+if __name__ == "__main__":
+    path1 = "amusement/amusement/Easy/P001/image_right"
+    path2 = "amusement/amusement/Easy/P001/image_left"
+
+    data = FromDirectoryDataset(dirs={"right": [path1, path1], "left": [path2, path2]}, slice=[0.2, 0.3])
+    for i in range(len(data)):
+        print(data[i])

--- a/alonet/common/pl_helpers.py
+++ b/alonet/common/pl_helpers.py
@@ -10,13 +10,16 @@ import torch
 parser = ArgumentParser()
 
 
-def vb_folder():
+def vb_folder(create_if_not_found=False):
     home = os.getenv("HOME")
     alofolder = os.path.join(home, ".aloception")
     if not os.path.exists(alofolder):
-        raise Exception(
-            f"{alofolder} do not exist. Please, create the folder with the appropriate files. (Checkout documentation)"
-        )
+        if create_if_not_found:
+            os.mkdir(alofolder)
+        else:
+            raise Exception(
+                f"{alofolder} do not exist. Please, create the folder with the appropriate files. (Checkout documentation)"
+            )
     return alofolder
 
 

--- a/alonet/common/weights.py
+++ b/alonet/common/weights.py
@@ -1,6 +1,7 @@
 import torch
 import requests
 import os
+from alonet.common.pl_helpers import vb_folder
 
 WEIGHT_NAME_TO_FILES = {
     "detr-r50": ["https://storage.googleapis.com/visualbehavior-publicweights/detr-r50/detr-r50.pth"],
@@ -30,14 +31,6 @@ WEIGHT_NAME_TO_FILES = {
 }
 
 
-def vb_fodler():
-    home = os.getenv("HOME")
-    alofolder = os.path.join(home, ".aloception")
-    if not os.path.exists(alofolder):
-        os.mkdir(alofolder)
-    return alofolder
-
-
 def load_weights(model, weights, device, strict_load_weights=True):
     """Load and/or download weights from public cloud
 
@@ -50,7 +43,7 @@ def load_weights(model, weights, device, strict_load_weights=True):
     device: torch.device
         Device to load the weights into
     """
-    weights_dir = os.path.join(vb_fodler(), "weights")
+    weights_dir = os.path.join(vb_folder(), "weights")
 
     if not os.path.exists(weights_dir):
         os.makedirs(weights_dir)

--- a/alonet/deformable_detr/trt_exporter.py
+++ b/alonet/deformable_detr/trt_exporter.py
@@ -121,7 +121,7 @@ class DeformableDetrTRTExporter(BaseTRTExporter):
 
 if __name__ == "__main__":
     # test script
-    from alonet.common.weights import vb_fodler
+    from alonet.common.pl_helpers import vb_folder
 
     load_trt_plugins_for_deformable_detr()
     device = torch.device("cuda")
@@ -143,7 +143,7 @@ if __name__ == "__main__":
         model = DeformableDetrR50(weights=model_name, tracing=True, aux_loss=False).eval()
 
     if args.onnx_path is None:
-        args.onnx_path = os.path.join(vb_fodler(), "weights", model_name, model_name + ".onnx")
+        args.onnx_path = os.path.join(vb_folder(), "weights", model_name, model_name + ".onnx")
 
     input_shape = [3] + list(args.HW)
 

--- a/alonet/deformable_detr_panoptic/trt_exporter.py
+++ b/alonet/deformable_detr_panoptic/trt_exporter.py
@@ -83,7 +83,7 @@ class PanopticTRTExporter(BaseTRTExporter):
 
 if __name__ == "__main__":
     raise NotImplementedError("Not implemented yet")
-    from alonet.common.weights import vb_fodler
+    from alonet.common.pl_helpers import vb_folder
     from alonet.detr_panoptic import PanopticHead
     from alonet.detr import DetrR50
     from alonet.detr.trt_exporter import DetrTRTExporter
@@ -104,7 +104,7 @@ if __name__ == "__main__":
     args = parser.parse_args()
     device = torch.device("cpu") if args.cpu else torch.device("cuda")
     input_shape = [3] + list(args.HW)
-    pan_onnx_path = os.path.join(vb_fodler(), "weights", "detr-r50-panoptic")
+    pan_onnx_path = os.path.join(vb_folder(), "weights", "detr-r50-panoptic")
     if args.split_engines:
         pan_onnx_path = os.path.join(pan_onnx_path, "panoptic-head.onnx")
     else:

--- a/alonet/detr/trt_exporter.py
+++ b/alonet/detr/trt_exporter.py
@@ -50,7 +50,7 @@ class DetrTRTExporter(BaseTRTExporter):
 
 
 if __name__ == "__main__":
-    from alonet.common.weights import vb_fodler
+    from alonet.common.pl_helpers import vb_folder
 
     # test script
     parser = argparse.ArgumentParser()
@@ -62,7 +62,7 @@ if __name__ == "__main__":
     # parser.add_argument("--image_chw")
     args = parser.parse_args()
     if args.onnx_path is None:
-        args.onnx_path = os.path.join(vb_fodler(), "weights", "detr-r50", "detr-r50.onnx")
+        args.onnx_path = os.path.join(vb_folder(), "weights", "detr-r50", "detr-r50.onnx")
     device = torch.device("cpu") if args.cpu else torch.device("cuda")
 
     input_shape = [3] + list(args.HW)

--- a/alonet/detr_panoptic/trt_exporter.py
+++ b/alonet/detr_panoptic/trt_exporter.py
@@ -82,7 +82,7 @@ class PanopticTRTExporter(BaseTRTExporter):
 
 
 if __name__ == "__main__":
-    from alonet.common.weights import vb_fodler
+    from alonet.common.pl_helpers import vb_folder
     from alonet.detr_panoptic import PanopticHead
     from alonet.detr import DetrR50
     from alonet.detr.trt_exporter import DetrTRTExporter
@@ -103,7 +103,7 @@ if __name__ == "__main__":
     args = parser.parse_args()
     device = torch.device("cpu") if args.cpu else torch.device("cuda")
     input_shape = [3] + list(args.HW)
-    pan_onnx_path = os.path.join(vb_fodler(), "weights", "detr-r50-panoptic")
+    pan_onnx_path = os.path.join(vb_folder(), "weights", "detr-r50-panoptic")
     if args.split_engines:
         pan_onnx_path = os.path.join(pan_onnx_path, "panoptic-head.onnx")
     else:

--- a/alonet/torch2trt/base_exporter.py
+++ b/alonet/torch2trt/base_exporter.py
@@ -55,6 +55,7 @@ class BaseTRTExporter:
         opt_profiles: Dict[str, Tuple[List[int]]] = None,
         profiling_verbosity: int = 0,
         calibrator=None,
+        max_workspace_size: int = 1,
         **kwargs,
     ):
         """
@@ -93,6 +94,8 @@ class BaseTRTExporter:
                 1 : NONE (Do not print any layer information).
                 2 : DETAILED : (Print detailed layer information including layer names and layer parameters).
             Set to 2 for more layers details (preicision, type, kernel ...) when calling the EngineInspector
+        max_workspace_size : int
+            Maximum work size in GiB.
 
         Raises
         ------
@@ -133,7 +136,13 @@ class BaseTRTExporter:
         else:
             trt_logger = trt.Logger(trt.Logger.WARNING)
 
-        self.engine_builder = TRTEngineBuilder(self.onnx_path, logger=trt_logger, opt_profiles=opt_profiles, calibrator=calibrator)
+        self.engine_builder = TRTEngineBuilder(
+            self.onnx_path,
+            logger=trt_logger,
+            calibrator=calibrator,
+            opt_profiles=opt_profiles,
+            max_workspace_size=max_workspace_size
+            )
 
         if profiling_verbosity == 0:
             self.engine_builder.profiling_verbosity = "LAYER_NAMES_ONLY"
@@ -148,7 +157,6 @@ class BaseTRTExporter:
             pass
         elif precision.lower() == "int8":
             self.engine_builder.INT8_allowed = True
-            self.engine_builder.FP16_allowed = True
             self.engine_builder.strict_type = True
         elif precision.lower() == "fp16":
             self.engine_builder.FP16_allowed = True

--- a/aloscene/bounding_boxes_2d.py
+++ b/aloscene/bounding_boxes_2d.py
@@ -55,11 +55,11 @@ class BoundingBoxes2D(aloscene.tensors.AugmentedTensor):
     --------
     >>> boxes2d = aloscene.BoundingBoxes2D(
     ...     [[0.5, 0.5, 01, 01], [0.4, 0.30, 0.2, 0.3]],
-    ...     points_format="xcyc", absolute=False
+    ...     boxes_format="xcyc", absolute=False
     ....)
     >>> boxes2d = aloscene.BoundingBoxes2D(
     ...     [[512, 458, 20, 30], [280, 200, 100, 42]],
-    ...     points_format="xcyc", absolute=True, frame_size=(1200, 1200)
+    ...     boxes_format="xcyc", absolute=True, frame_size=(1200, 1200)
         )
     """
 

--- a/aloscene/bounding_boxes_2d.py
+++ b/aloscene/bounding_boxes_2d.py
@@ -487,8 +487,9 @@ class BoundingBoxes2D(aloscene.tensors.AugmentedTensor):
 
             if label is not None:
                 color = self._GLOBAL_COLOR_SET[int(label) % len(self._GLOBAL_COLOR_SET)]
+                text = label.labels_names[int(label)] if label.labels_names else int(label)
                 cv2.putText(
-                    frame, str(int(label)), (int(x2), int(y1)), cv2.FONT_HERSHEY_SIMPLEX, 0.5, color, 1, cv2.LINE_AA
+                    frame, str(text), (int(x2), int(y1)), cv2.FONT_HERSHEY_SIMPLEX, 0.5, color, 1, cv2.LINE_AA
                 )
                 cv2.rectangle(frame, (int(x1), int(y1)), (int(x2), int(y2)), color, 3)
             else:

--- a/aloscene/bounding_boxes_2d.py
+++ b/aloscene/bounding_boxes_2d.py
@@ -33,7 +33,7 @@ class BoundingBoxes2D(aloscene.tensors.AugmentedTensor):
     x: list | torch.Tensor | np.array
         BoundingBoxes2D data. See explanation above for details.
     boxes_format: str
-        One of `xyxy` (y_min, x_min, y_max, x_max), `yxyx` (x_min, y_min, x_max, y_max) or `xcyc` (xc, yc, width,
+        One of `xyxy` (x_min, y_min, x_max, y_max), `yxyx` (y_min, x_min, y_max, x_max) or `xcyc` (xc, yc, width,
         height)
     absolute: bool
         Whether your boxes are encoded as absolute value or relative values (between 0 and 1). If absolute is True,

--- a/aloscene/bounding_boxes_3d.py
+++ b/aloscene/bounding_boxes_3d.py
@@ -56,6 +56,34 @@ class BoundingBoxes3D(aloscene.tensors.AugmentedTensor):
             )
             raise import_error
 
+    def append_labels(self, labels: Labels, name: Union[str, None] = None):
+        """Attach a set of labels to the boxes. The attached set of labels are supposed to be equal to the
+        number of points. In other words, the N dimensions must match in both tensor.
+        Parameters
+        ----------
+        labels: aloscene.Labels
+            Set of labels to attached to the bounding boxes
+        name: str
+            If none, the label will be attached without name (if possible). Otherwise if no other unnamed
+            labels are attached to the bounding boxes, the labels will be added to the set of labels.
+        Examples
+        --------
+        >>> boxes3d = aloscene.BoundingBoxes3D([[0.5, 0.5, 0.1, 0.1], [0.2, 0.1, 0.05, 0.05]], "xcyc", False)
+        >>> labels = aloscene.Labels([51, 24])
+        >>> boxes3d.append_labels(labels)
+        >>> boxes3d.labels
+        >>>
+        Or using named labels
+        >>> boxes3d = aloscene.BoundingBoxes3D([[0.5, 0.5, 0.1, 0.1], [0.2, 0.1, 0.05, 0.05]], "xcyc", False)
+        >>> labels_set_1 = aloscene.Labels([51, 24])
+        >>> labels_set_2 = aloscene.Labels([51, 24])
+        >>> boxes3d.append_labels(labels_set_1, "set1")
+        >>> boxes3d.append_labels(labels_set_2, "set2")
+        >>> boxes3d.labels["set1"]
+        >>> boxes3d.labels["set2"]
+        """
+        self._append_child("labels", labels, name)
+
     @staticmethod
     def get_vertices_3d(boxes) -> torch.Tensor:
         """Get 8 vertices for each boxes in x, y, z coordinates

--- a/aloscene/bounding_boxes_3d.py
+++ b/aloscene/bounding_boxes_3d.py
@@ -62,10 +62,10 @@ class BoundingBoxes3D(aloscene.tensors.AugmentedTensor):
         Parameters
         ----------
         labels: aloscene.Labels
-            Set of labels to attached to the bounding boxes
+            Set of labels to attached to the BoundingBoxes3D
         name: str
             If none, the label will be attached without name (if possible). Otherwise if no other unnamed
-            labels are attached to the bounding boxes, the labels will be added to the set of labels.
+            labels are attached to the BoundingBoxes3D, the labels will be added to the set of labels.
         Examples
         --------
         >>> boxes3d = aloscene.BoundingBoxes3D([[0.5, 0.5, 0.1, 0.1], [0.2, 0.1, 0.05, 0.05]], "xcyc", False)
@@ -74,7 +74,7 @@ class BoundingBoxes3D(aloscene.tensors.AugmentedTensor):
         >>> boxes3d.labels
         >>>
         Or using named labels
-        >>> boxes3d = aloscene.BoundingBoxes3D([[0.5, 0.5, 0.1, 0.1], [0.2, 0.1, 0.05, 0.05]], "xcyc", False)
+        >>> boxe3d = aloscene.BoundingBoxes3D([[0.5, 0.5, 0.1, 0.1], [0.2, 0.1, 0.05, 0.05]], "xcyc", False)
         >>> labels_set_1 = aloscene.Labels([51, 24])
         >>> labels_set_2 = aloscene.Labels([51, 24])
         >>> boxes3d.append_labels(labels_set_1, "set1")

--- a/aloscene/camera_calib.py
+++ b/aloscene/camera_calib.py
@@ -158,8 +158,8 @@ class CameraIntrinsic(AugmentedTensor):
         pad_top = offset_y[0] * frame_size[0]
         pad_left = offset_x[0] * frame_size[1]
         cam_intrinsic = self.clone()
-        cam_intrinsic[..., 0, 2] += pad_top
-        cam_intrinsic[..., 1, 2] += pad_left
+        cam_intrinsic[..., 0, 2] += pad_left
+        cam_intrinsic[..., 1, 2] += pad_top
         return cam_intrinsic
 
     def get_view(self, *args, **kwargs):

--- a/aloscene/frame.py
+++ b/aloscene/frame.py
@@ -129,9 +129,15 @@ class Frame(aloscene.tensors.SpatialAugmentedTensor):
         tensor.add_child("scene_flow", labels, align_dim=["B", "T"], mergeable=False)
 
         # Add other tensor property
+        assert normalization in {"01", "255", "minmax_sym", "resnet"}, f"{normalization} norm is not yet supported"
         tensor.add_property("normalization", normalization)
-        tensor.add_property("_resnet_mean_std", ((0.485, 0.456, 0.406), (0.229, 0.224, 0.225)))
-        tensor.add_property("mean_std", mean_std)
+
+        resnet_rgb_mean_std = ((0.485, 0.456, 0.406), (0.229, 0.224, 0.225))
+        tensor.add_property("_resnet_mean_std", resnet_rgb_mean_std)
+        if normalization == "resnet":
+            tensor.add_property("mean_std", resnet_rgb_mean_std)
+        else:
+            tensor.add_property("mean_std", mean_std)
 
         return tensor
 

--- a/aloscene/tensors/augmented_tensor.py
+++ b/aloscene/tensors/augmented_tensor.py
@@ -611,6 +611,9 @@ class AugmentedTensor(torch.Tensor):
             self_ref_tensor = self.rename_(*self._saved_names)
             self_ref_tensor._saved_names = None
             return self_ref_tensor
+        elif self._saved_names is not None and not any(v is not None for v in self._saved_names):
+            self._saved_names = None
+            return self
         else:
             return self
 

--- a/aloscene/tensors/augmented_tensor.py
+++ b/aloscene/tensors/augmented_tensor.py
@@ -1,5 +1,6 @@
 import torch
 import inspect
+import warnings
 import numpy as np
 from typing import *
 import copy
@@ -10,6 +11,10 @@ class AugmentedTensor(torch.Tensor):
 
     # Common dim names that must be aligned to handle label on a Tensor.
     COMMON_DIM_NAMES = ["B", "T"]
+
+    # Ignore named tansors userwarning.
+    ERROR_MSG = "Named tensors and all their associated APIs are an experimental feature and subject to change"
+    warnings.filterwarnings(action='ignore', message=ERROR_MSG)
 
     @staticmethod
     def __new__(cls, x, names=None, device=None, *args, **kwargs):

--- a/aloscene/tensors/spatial_augmented_tensor.py
+++ b/aloscene/tensors/spatial_augmented_tensor.py
@@ -557,8 +557,8 @@ class SpatialAugmentedTensor(AugmentedTensor):
         except AttributeError:
             return label
 
-    def _pad(self, offset_y: tuple, offset_x: tuple, value=0, **kwargs):
-        """Pad the based on the given offset
+    def _pad(self, offset_y: tuple, offset_x: tuple, **kwargs):
+        """Pad `self` based on the given offset
 
         Parameters
         ----------
@@ -569,7 +569,7 @@ class SpatialAugmentedTensor(AugmentedTensor):
 
         Returns
         -------
-        padded
+            padded `self`
         """
         pad_top = int(round(offset_y[0] * self.H))
         pad_bottom = int(round(offset_y[1] * self.H))
@@ -577,7 +577,7 @@ class SpatialAugmentedTensor(AugmentedTensor):
         pad_right = int(round(offset_x[1] * self.W))
 
         padding = [pad_left, pad_top, pad_right, pad_bottom]
-        tensor_padded = F.pad(self.rename(None), padding, padding_mode="constant", fill=value).reset_names()
+        tensor_padded = F.pad(self.rename(None), padding, **kwargs).reset_names()
         return tensor_padded
 
     def _getitem_child(self, label, label_name, idx):

--- a/aloscene/tensors/spatial_augmented_tensor.py
+++ b/aloscene/tensors/spatial_augmented_tensor.py
@@ -206,13 +206,14 @@ class SpatialAugmentedTensor(AugmentedTensor):
             assert x.is_integer(), f"relative coordinates {x} have produced non-integer absolute coordinates"
         return round(x)
 
-    def temporal(self, dim=0):
+    def temporal(self, dim=None):
         """Add a temporal dimension on the tensor
 
         Parameters
         ----------
-        dim : int
-            The dim on which to add the temporal dimension. Can be 0 or 1
+        dim : int or None
+            The dim on which to add the temporal dimension. Can be 0 or 1 or None.
+            None automatically determine position of T dim in respect of convention.
 
         Returns
         -------
@@ -221,6 +222,16 @@ class SpatialAugmentedTensor(AugmentedTensor):
         """
         if "T" in self.names:  # Already a temporal frame
             return self
+
+        if dim is None:
+            if self.names[0] == "B":
+                dim = 1
+            elif "B" in self.names:
+                raise Exception(
+                    "Cannot autodetermine temporal dimension position : tensor doesn't follow convention (B, T, ...) )"
+                )
+            else:
+                dim = 0
 
         def set_n_names(names):
             pass

--- a/aloscene/tensors/spatial_augmented_tensor.py
+++ b/aloscene/tensors/spatial_augmented_tensor.py
@@ -557,7 +557,7 @@ class SpatialAugmentedTensor(AugmentedTensor):
         except AttributeError:
             return label
 
-    def _pad(self, offset_y: tuple, offset_x: tuple, **kwargs):
+    def _pad(self, offset_y: tuple, offset_x: tuple, value=0, **kwargs):
         """Pad `self` based on the given offset
 
         Parameters


### PR DESCRIPTION
To try it out I used a code like this: (try it out with an actual image to check it out)

import numpy as np
import torch
from aloscene import Frame, Labels, BoundingBoxes3D, CameraExtrinsic, CameraIntrinsic, BoundingBoxes2D

frame = Frame(np.zeros((3, 500, 500)), normalization="01")
# frame = Frame("/home/flo/rosbags/vb_office_cartons/RGB/2736_color.png", normalization="01")
frame.append_cam_intrinsic(CameraIntrinsic(focal_length=616.0, plane_size=frame.HW))
frame.append_cam_extrinsic(CameraExtrinsic(torch.eye(4, dtype=torch.float32)))
label = Labels([1], names=["name"])

box3d = BoundingBoxes3D([[0.75, 0.05, 2.5, 0.4, 0.5, 0.25, 0.5]], labels=label)
frame.append_boxes3d(box3d)

box2d = BoundingBoxes2D(
    [[200, 200, 200, 300]], boxes_format="xcyc", absolute=True, frame_size=(500, 500), labels=label
)
frame.append_boxes2d(box2d)

# frame1 = Frame("/home/flo/Pictures/continuous_walss.png", normalization="01")

# frames = torch.cat([frame.batch(), frame1.batch()], dim=0)
frame1 = frame.pad((0.3, 0.1), (0.1, 0.3))

print(frame.size(), frame1.size())
frame.get_view().render()
frame1.get_view().render()
# frames.get_view().render()
