### PR TITLE
Fix boxes3d for points with negative depth

### DIFF
--- a/aloscene/bounding_boxes_3d.py
+++ b/aloscene/bounding_boxes_3d.py
@@ -173,7 +173,7 @@ class BoundingBoxes3D(aloscene.tensors.AugmentedTensor):
 
         if torch.any(neg_mask):
             neg_coord = torch.where(neg_mask)
-            # find the 2 other points linked to the first
+            # find the 2 possible linked points  inside frame
             pair1 = (neg_coord[1] + 4) % 8
             pair2 = neg_coord[1] - (neg_coord[1] % 2) * 2 + 1
 


### PR DESCRIPTION
This fixes issue #225, encountered when some points of boxes3d have negative depth (part of the object is behind the camera).

Points with negative depth are re-projected to positive depth by negating them. The line is then extend to outside the image to keep it coherent.

To extend the line, I compute the normalized vector from the linked point inside the frame to the point with negated depth (in image space). I then rescale the vector and add it to the negated point to extend outside the visible frame.

To find the right linked point, I take the furthest away from the point of negative depth. There is only 2 possible points since the third also has negative depth and thus there is no visible line that can can be seen from it. 

The only limitation of this technique is if a point has negative depth and linked to two points in the visible image then one of the line will be distorted.

I also fix NaN when depth = 0.

Code to replicate results:

```py
import numpy as np
from aloscene import Frame, BoundingBoxes3D, CameraExtrinsic, CameraIntrinsic

frame = Frame(np.zeros((3, 1000, 1000)))
intrisic = CameraIntrinsic(np.array([[500, 0.0, 500, 0.0], [0.0, 500, 500, 0.0], [0, 0, 1, 0]]))
extrinsic = CameraExtrinsic(np.array([[1, 0, 0, 0.062169], [0, 1, 0, 0], [0, 0, 1, 0], [0, 0, 0, 1]]))
frame.append_cam_intrinsic(intrisic)
frame.append_cam_extrinsic(extrinsic)
box3d = BoundingBoxes3D([[-1, -1, 3, 1, 1, 10, 0], [1, 1, 3, 10, 1, 1, np.pi/3]])
frame.append_boxes3d(box3d)

frame.get_view([frame.boxes3d]).render()

```
