### PR TITLE
alobugdays : added center to rotate

### DIFF
--- a/alodataset/transforms.py
+++ b/alodataset/transforms.py
@@ -553,24 +553,28 @@ class Resize(AloTransform):
 
 
 class Rotate(AloTransform):
-    def __init__(self, angle: float, *args, **kwargs):
-        """Rotate the given frame using the given rotation angle.
+    def __init__(self, angle: float, center=None, *args, **kwargs):
+        """Rotate the given frame using the given rotation angle around the given rotation center.
 
         Parameters
         ----------
         angle: float, between 0 and 360
+        center: list or tuple of coordinates.
+            Coordinates should be in absolute format (in range [0, W] and [0, H]). Default is the center of the frame.
         """
         assert isinstance(angle, float)
         self.angle = angle
+        self.center = center
         super().__init__(*args, **kwargs)
 
     def sample_params(self):
         """Sample an `angle` from the list of possible `angles`"""
-        return (self.angle,)
+        return (self.angle, self.center)
 
-    def set_params(self, angle):
+    def set_params(self, angle, center):
         """Given predefined params, set the params on the class"""
         self.angle = angle
+        self.center = center
 
     def apply(self, frame: Frame):
         """Apply the transformation
@@ -580,7 +584,7 @@ class Rotate(AloTransform):
         frame: Frame
             Frame to apply the transformation on
         """
-        frame = frame.rotate(self.angle)
+        frame = frame.rotate(self.angle, self.center)
         return frame
 
 

--- a/aloscene/tensors/augmented_tensor.py
+++ b/aloscene/tensors/augmented_tensor.py
@@ -860,13 +860,14 @@ class AugmentedTensor(torch.Tensor):
     def _resize(self, *args, **kwargs):
         raise Exception("This Augmented tensor should implement this method")
 
-    def rotate(self, angle, **kwargs):
+    def rotate(self, angle, center=None,**kwargs):
         """
         Rotate AugmentedTensor, and its labels recursively
 
         Parameters
         ----------
         angle : float
+        center : list or tuple of coordinates in absolute format. Default is the center of the image
 
         Returns
         -------
@@ -876,12 +877,12 @@ class AugmentedTensor(torch.Tensor):
 
         def rotate_func(label):
             try:
-                label_rotated = label._rotate(angle, **kwargs)
+                label_rotated = label._rotate(angle, center,**kwargs)
                 return label_rotated
             except AttributeError:
                 return label
 
-        rotated = self._rotate(angle, **kwargs)
+        rotated = self._rotate(angle, center,**kwargs)
         rotated.recursive_apply_on_children_(rotate_func)
 
         return rotated

--- a/aloscene/tensors/spatial_augmented_tensor.py
+++ b/aloscene/tensors/spatial_augmented_tensor.py
@@ -499,12 +499,14 @@ class SpatialAugmentedTensor(AugmentedTensor):
             return self.rename(None).view(shapes).reset_names()
         return F.resize(self.rename(None), (h, w), interpolation=interpolation).reset_names()
 
-    def _rotate(self, angle, **kwargs):
+    def _rotate(self, angle, center=None,**kwargs):
         """Rotate SpatialAugmentedTensor, but not its labels
 
         Parameters
         ----------
         angle : float
+        center : list or tuple of coordinates in absolute format. Default is the center of the image
+
 
         Returns
         -------
@@ -515,7 +517,7 @@ class SpatialAugmentedTensor(AugmentedTensor):
         assert not (
             ("N" in self.names and self.size("N") == 0) or ("C" in self.names and self.size("C") == 0)
         ), "rotation is not possible on an empty tensor"
-        return F.rotate(self.rename(None), angle).reset_names()
+        return F.rotate(self.rename(None), angle,center=center).reset_names()
 
     def _crop(self, H_crop: tuple, W_crop: tuple, **kwargs):
         """Crop the SpatialAugmentedTensor


### PR DESCRIPTION
- ***New feature 1*** : Rotate frame around a custom center

Torchvision Rotate transform supports the possibility to pass a "center" argument to rotate around a given center (and not only around the image center). I added this functionality to our Rotate Alotransform

```
from alodataset.coco_base_dataset import CocoBaseDataset
from alodataset.transforms import Rotate

coco_dataset = CocoBaseDataset(sample=True)
x = coco_dataset[0]
angle = 15.0
x = Rotate(angle, center=[650, 0])(x)
x.get_view().render()
```
This pull request includes

- [ ]  Bug fix (non-breaking change which fixes an issue)
- [X]  New feature (non-breaking change which adds functionality)
- [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ]  This change requires a documentation update