### PR TITLE
17 Not integer crop within recursion

### DIFF
--- a/aloscene/tensors/spatial_augmented_tensor.py
+++ b/aloscene/tensors/spatial_augmented_tensor.py
@@ -12,6 +12,7 @@ import aloscene
 from aloscene.camera_calib import CameraExtrinsic, CameraIntrinsic
 from aloscene.utils.data_utils import LDtoDL
 
+import warnings
 
 class SpatialAugmentedTensor(AugmentedTensor):
     """Spatial Augmented Tensor. Used to represets any 2D data. The spatial augmented tensor can be used as a
@@ -196,7 +197,7 @@ class SpatialAugmentedTensor(AugmentedTensor):
         view = Renderer.get_grid_view(n_views, grid_size=grid_size, cell_grid_size=size, add_title=add_title, **kwargs)
         return View(view)
 
-    def relative_to_absolute(self, x, dim, assert_integer=False):
+    def relative_to_absolute(self, x, dim, assert_integer=False, warn_non_integer=False):
         dim = dim.lower()
         assert dim in ["h", "w"], "dim should be 'h' or 'w'"
         ref = self.H if dim == "h" else self.W
@@ -204,6 +205,10 @@ class SpatialAugmentedTensor(AugmentedTensor):
 
         if assert_integer:
             assert x.is_integer(), f"relative coordinates {x} have produced non-integer absolute coordinates"
+
+        if warn_non_integer and not x.is_integer():
+            warnings.warn(f"relative coordinates {x} have produced non-integer absolute coordinates")
+
         return round(x)
 
     def temporal(self, dim=None):
@@ -396,7 +401,7 @@ class SpatialAugmentedTensor(AugmentedTensor):
 
         return n_augmented_tensors
 
-    def _relative_to_absolute_hs_ws(self, hs=None, ws=None, assert_integer=True):
+    def _relative_to_absolute_hs_ws(self, hs=None, ws=None, assert_integer=True, warn_non_integer=False):
         """
         Parameters
         ----------
@@ -409,9 +414,9 @@ class SpatialAugmentedTensor(AugmentedTensor):
         assert hs is None or isinstance(hs, (list, tuple)), "hs should be a list or a tuple of floats"
         assert ws is None or isinstance(ws, (list, tuple)), "ws should be a list or a tuple of floats"
         if hs is not None:
-            hs = [self.relative_to_absolute(h, "H", assert_integer) for h in hs]
+            hs = [self.relative_to_absolute(h, "H", assert_integer=assert_integer, warn_non_integer=warn_non_integer) for h in hs]
         if ws is not None:
-            ws = [self.relative_to_absolute(w, "W", assert_integer) for w in ws]
+            ws = [self.relative_to_absolute(w, "W", assert_integer=assert_integer, warn_non_integer=warn_non_integer) for w in ws]
         return hs, ws
 
     def _hflip_label(self, label, **kwargs):
@@ -543,7 +548,8 @@ class SpatialAugmentedTensor(AugmentedTensor):
         cropped sa_tensor: aloscene.SpatialAugmentedTensor
             cropped SpatialAugmentedTensor
         """
-        H_crop, W_crop = self._relative_to_absolute_hs_ws(H_crop, W_crop, assert_integer=False)
+
+        H_crop, W_crop = self._relative_to_absolute_hs_ws(H_crop, W_crop, assert_integer=False, warn_non_integer=True)
         hmin, hmax = H_crop
         wmin, wmax = W_crop
         slices = self.get_slices({"H": slice(hmin, hmax), "W": slice(wmin, wmax)})


### PR DESCRIPTION
#17 

To reproduce : 
```
from aloscene import Frame, Flow
import numpy as np

import warnings

frame = Frame(np.random.uniform(0, 1, (3, 14, 14)), names=("C", "H", "W"))
flow  = Flow(np.random.uniform(0, 1, (2, 7, 7)), names=("C", "H", "W"))
frame.append_flow(flow)

top, left = (1, 4)
h, w = (3, 4)


print(f"frame_cropped:\t{frame_cropped.names} = {tuple(frame_cropped.shape)}")
print(f"frame_cropped.flow:\t{frame_cropped.flow.names} = {tuple(frame_cropped.flow.shape)}")
```

__New behavior : Display warning when non-integer crop append__

To remove this specific warning : 
```
with warnings.catch_warnings():
    warnings.simplefilter('ignore', UserWarning)
    frame_cropped = frame[:, top:top+h, left:left+w]

```