### PR TITLE
Alobugdays : Renderer class

### DIFF
--- a/aloscene/renderer/renderer.py
+++ b/aloscene/renderer/renderer.py
@@ -2,10 +2,6 @@ import numpy as np
 import cv2
 import math
 import matplotlib.pyplot as plt
-import matplotlib
-from abc import ABC, abstractmethod
-import numpy as np
-import cv2
 
 
 def adapt_text_size_to_frame(size, frame_size):

--- a/aloscene/renderer/renderer.py
+++ b/aloscene/renderer/renderer.py
@@ -9,6 +9,15 @@ import cv2
 
 
 def adapt_text_size_to_frame(size, frame_size):
+    """Adapt text size to frame.
+
+    Parameters
+    ----------
+    size : float
+        Size factor
+    frame_size : tuple
+        Frame size (height, width)
+    """
     base_size_h = size * frame_size[1] / 1000
     base_size_w = size * frame_size[0] / 1000
     return base_size_h, base_size_w
@@ -29,14 +38,24 @@ def put_adapative_cv2_text(
 
     Parameters
     ----------
-    frame: np.array
+    frame: np.ndarray
         Frame to put the text on
-    frame_size: np.array
+    frame_size: tuple
         Frame size (height, width)
     text: str
-        Text do display
-    pos_x: int
-    pos_y: int
+        Text to display
+    pos_x: float
+        Starting x position
+    pos_y: float
+        Starting y position
+    text_color: tuple, optional
+        Text RGB color, by default None.
+    background_color: tuple, optional
+        Background RGB color, by default None.
+    square_background: bool, optional
+        Add square background if True, by default True.
+    views_counter: int, optional
+        Number of views in the final image, by default None.
     """
     size_h, size_w = adapt_text_size_to_frame(1.0, frame_size)
 
@@ -79,17 +98,18 @@ class View(object):
     MATPLOTLIB = "matplotlib"
 
     def __init__(self, image, title=None, **kwargs):
-        """ The view class is used to store the information about one view and set
+        """The view class is used to store the information about one view and set
         the parameters that could be automaticly changed during the scene rendering.
 
         Parameters
         ----------
-        image: (np.ndarray)
+        image : np.ndarray
             The image on which to display the new information. The image values must be\
             between 0 and 1. If the image is None, we assume, the view object returns its \
             own image of the scene.
-        title: str
-            Title of the view """
+        title : str, optional
+            Title of the view, by default None.
+        """
         if image.shape[-1] == 1:
             image = cv2.cvtColor(image, cv2.COLOR_GRAY2RGB)
 
@@ -97,15 +117,18 @@ class View(object):
         self.title = title
 
     def render(self, method="matplotlib", location: str = None, figsize=[6.4, 4.8]):
-        """Render the current view using "matplotlib" or
-        opencv ("cv")
+        """Render the current view using "matplotlib" or opencv ("cv").
 
         Parameters
         ----------
-        method: str
+        method : str, optional
             One of ("cv", "matplotlib") or (View.CV, View.MATPLOTLIB). "matplotlib" by default.
-        location: str
-            Do not render using matplotlib or opencv, but save the view into the given location"""
+        location : str, optional
+            Do not render using matplotlib or opencv, but save the view into the given location.
+            By default None.
+        figsize : list, optional
+            Figure size if using matplotlib, by default [6.4, 4.8].
+            """
         if location is not None:
             plt.figure(figsize=figsize, tight_layout=True)
             plt.imshow(self.image)
@@ -126,16 +149,22 @@ class View(object):
             raise Exception(f"render method {method} is not handle")
 
     def add(self, view):
-        """Extend the view with an other view"""
-        return View(Renderer.get_grid_view([self, view]))
-
-    def save(self, location):
-        """Save the current view into the given location
+        """Extend the view with another view.
 
         Parameters
         ----------
-        location: (str)
-            Path to the image to save
+        view : renderer.View
+            View to add.
+        """
+        return View(Renderer.get_grid_view([self, view]))
+
+    def save(self, location):
+        """Save the current view into the given location.
+
+        Parameters
+        ----------
+        location : str
+            Path to the image to save.
         """
         cv2.imwrite(location, self.image[:, :, ::-1] * 255)
 
@@ -147,21 +176,45 @@ class Renderer(object):
         self.out_shape = None
 
     def _cv_render(self, view: np.ndarray):
-        """Render using opencv"""
+        """Render using opencv.
+
+        Parameters
+        ----------
+        view : np.ndarray
+            View to render.
+        """
         view = view[:, :, ::-1]
         cv2.imshow("Cortex view", view)
         if cv2.waitKey(1) & 0xFF == ord("q"):
             return False
 
     def _matplotlib_render(self, view: np.ndarray):
-        """Render using opencv"""
+        """Render using opencv.
+
+        Parameters
+        ----------
+        view : np.ndarray
+            View to render.
+        """
         plt.imshow(view)
         plt.show()
 
     @classmethod
     def get_grid_view(cls, views: list, cell_grid_size=None, grid_size=None, add_title=True, **kwargs):
-        """Get a grid of view from multiple view"""
+        """Get a grid of view from multiple view.
 
+        Parameters
+        ----------
+        views : list
+            List of views.
+        cell_grid_size : tuple, optional
+            If not None, the tuple values (height, width) will be used
+            to set the size of the each grid cell of the display. By default None.
+        grid_size : int, optional
+            Number of views in the final grid, by default None.
+        add_title : bool, optional
+            Add title on the view, by default True.
+        """
         smallest_view = None
         target_display_shape = cell_grid_size
         if target_display_shape is None:
@@ -196,17 +249,18 @@ class Renderer(object):
 
     @staticmethod
     def add_title(array, start, title, views_counter):
-        """
-        Add a box with view title
+        """Add a box with view title.
 
         Parameters
         ----------
         array : np.ndarray
-            grid view array (will be modified inplace)
+            Grid view array (will be modified inplace).
         start : tuple
-            top-left corner of title box
+            Top-left corner of title box.
         title : str
-            title of the view
+            Title of the view.
+        views_counter : int
+            Number of views.
         """
         if title is None:
             return
@@ -222,10 +276,12 @@ class Renderer(object):
 
     @classmethod
     def get_user_defined_grid_view(cls, views, add_title):
-        """
-        Create grid_view from list of list, without resizing views
+        """Create grid_view from list of list, without resizing views.
 
-        view : list of list of views with view[i][j] = view for line i, colomun j
+        view : list
+            List of list of views with view[i][j] = view for line i, colomun j
+        add_title : bool
+            Add title on the view if True.
         """
         # create blank image
         Hf, Wf = 0, 0
@@ -269,16 +325,22 @@ class Renderer(object):
         ----------
         views : list
             List of np.darray to display
-        renderer : str
-            String to set the renderer to use. Can be either ("cv" or "matplotlib")
-        cell_grid_size : tuple
+        renderer : str, optional
+            String to set the renderer to use. Can be either ("cv" or "matplotlib"). By default "cv".
+        cell_grid_size : tuple, optional
             Tuple or None. If not None, the tuple values (height, width) will be used
             to set the size of the each grid cell of the display. If only one view is used,
             the view will be resize to the cell grid size.
-        record_file : str
+        record_file : str, optional
             None by default. Used to save the rendering into one video.
+        fps: int, optional
+            FPS, by default 30.
+        grid_size : int, optional
+            Number of views in the grid, by default None.
         skip_views : bool, optional
-            Skip views, in order to speed up the render process, by default False
+            Skip views, in order to speed up the render process, by default False.
+        add_title : bool, optional
+            Add title on the view if True, by default True.
         """
         if renderer not in ["cv", "matplotlib"]:
             raise ValueError("The renderer must be one of the following:{}".format(self.renderer_to_fn.keys()))

--- a/aloscene/renderer/renderer.py
+++ b/aloscene/renderer/renderer.py
@@ -28,7 +28,7 @@ def put_adapative_cv2_text(
     text_color=None,
     background_color=None,
     square_background=True,
-    views_counter=None
+    grid_size=None
 ):
     """Put Text on the given frame with adaptive size.
 
@@ -50,20 +50,17 @@ def put_adapative_cv2_text(
         Background RGB color, by default None.
     square_background: bool, optional
         Add square background if True, by default True.
-    views_counter: int, optional
+    grid_size: int, optional
         Number of views in the final image, by default None.
     """
     size_h, size_w = adapt_text_size_to_frame(1.0, frame_size)
 
+    # Adapt text size to the number of views
+    if grid_size:
+        size_h /= grid_size
+        size_w /= grid_size
+
     (w, h), _ = cv2.getTextSize(text, cv2.FONT_HERSHEY_SIMPLEX, (size_h + size_w) / 2, -1)
-
-    # Decrease text size if too long
-    if views_counter:
-        if w > (frame_size[1] / (views_counter / 2)):
-            size_h /= 2
-            size_w /= 2
-
-            (w, h), _ = cv2.getTextSize(text, cv2.FONT_HERSHEY_SIMPLEX, (size_h + size_w) / 2, -1)
 
     pos_x = int(pos_x)
     pos_y = int(pos_y)
@@ -235,7 +232,7 @@ class Renderer(object):
             line[:, start : start + target_display_shape[1], :] = views[v].image
 
             if add_title:
-                cls.add_title(line, (start, 0), views[v].title, len(views))
+                cls.add_title(line, (start, 0), views[v].title, grid_size)
 
             v += 1
             if v % grid_size == 0 or v == len(views):
@@ -245,7 +242,7 @@ class Renderer(object):
         return np.concatenate(lines, axis=0)
 
     @staticmethod
-    def add_title(array, start, title, views_counter):
+    def add_title(array, start, title, grid_size):
         """Add a box with view title.
 
         Parameters
@@ -256,7 +253,7 @@ class Renderer(object):
             Top-left corner of title box.
         title : str
             Title of the view.
-        views_counter : int
+        grid_size : int
             Number of views.
         """
         if title is None:
@@ -269,7 +266,7 @@ class Renderer(object):
                                    start[1],
                                    text_color=(1, 1, 1),
                                    background_color=(0, 0, 0),
-                                   views_counter=views_counter)
+                                   grid_size=grid_size)
 
     @classmethod
     def get_user_defined_grid_view(cls, views, add_title):

--- a/aloscene/renderer/renderer.py
+++ b/aloscene/renderer/renderer.py
@@ -62,11 +62,12 @@ def put_adapative_cv2_text(
     (w, h), _ = cv2.getTextSize(text, cv2.FONT_HERSHEY_SIMPLEX, (size_h + size_w) / 2, -1)
 
     # Decrease text size if too long
-    if w > (frame_size[1] / (views_counter / 2)) and views_counter:
-        size_h /= 2
-        size_w /= 2
+    if views_counter:
+        if w > (frame_size[1] / (views_counter / 2)):
+            size_h /= 2
+            size_w /= 2
 
-        (w, h), _ = cv2.getTextSize(text, cv2.FONT_HERSHEY_SIMPLEX, (size_h + size_w) / 2, -1)
+            (w, h), _ = cv2.getTextSize(text, cv2.FONT_HERSHEY_SIMPLEX, (size_h + size_w) / 2, -1)
 
     pos_x = int(pos_x)
     pos_y = int(pos_y)


### PR DESCRIPTION
This PR fixes a small issue and improve documentation of the Renderer class.

* ***Adapt text size to number of views*** : views_counter is used to adapt text size to the number of views. But there is an error if views_counter is None. This PR fixes that issue (which was introduced by a previous PR - https://github.com/Visual-Behavior/aloception-oss/pull/275). Moreover, instead of using `views_counter`, use `grid_size` (which is the number of views in the grid)
To test it, use one dataset:
```
python3 alodataset/coco_base_dataset.py
```

* ***Update and add documentation*** 
_____
This pull request includes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
