### PR TITLE
alobugdays : added wandb hyperparams logging to pl helpers

### DIFF
--- a/alonet/common/pl_helpers.py
+++ b/alonet/common/pl_helpers.py
@@ -254,6 +254,8 @@ def run_pl_training(
     if args.log is not None:
         if args.log == "wandb":
             logger = WandbLogger(name=expe_name, project=project, id=expe_name)
+            logger.log_hyperparams(args)
+
         elif args.log == "tensorboard":
             logger = TensorBoardLogger(save_dir="tensorboard/", name=expe_name, sub_dir=expe_name)
         else:


### PR DESCRIPTION
- ***New feature 1*** : Added wandb hyperparameters logging

Now the hyperparameters are logged by default in wandb. The config of the experiment can be viewed in wandb=>overwiev=>config (see image below)

`python alonet/deformable_detr/train_on_coco.py --sample --log`

![image](https://user-images.githubusercontent.com/104132762/202738623-837d6ef8-e2b3-4f1c-8fd3-83ba772dee5d.png)

This pull request includes

- [ ]  Bug fix (non-breaking change which fixes an issue)
- [X]  New feature (non-breaking change which adds functionality)
- [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ]  This change requires a documentation update