### PR TITLE
253 labels information on boundingboxes3d

### DIFF
--- a/aloscene/bounding_boxes_2d.py
+++ b/aloscene/bounding_boxes_2d.py
@@ -423,8 +423,6 @@ class BoundingBoxes2D(aloscene.tensors.AugmentedTensor):
         else:
             return self.rel_area()
 
-    _GLOBAL_COLOR_SET = np.random.uniform(0, 1, (300, 3))
-
     def get_view(
         self,
         frame: Union[Tensor, None] = None,
@@ -461,7 +459,6 @@ class BoundingBoxes2D(aloscene.tensors.AugmentedTensor):
             boxes_abs = self.xyxy().abs_pos(frame.HW)
 
         # Get an imave with values between 0 and 1
-        frame_size = frame.HW
         frame = frame.norm01().cpu().rename(None).permute([1, 2, 0]).detach().contiguous().numpy()
         # Draw bouding boxes
 
@@ -470,9 +467,10 @@ class BoundingBoxes2D(aloscene.tensors.AugmentedTensor):
             labels = boxes_abs.labels
         elif isinstance(boxes_abs.labels, dict):
             labels = []
-            for k, v in boxes_abs.labels.items():
-                if isinstance(v, aloscene.Labels):
-                    labels.append(v)
+            # Sorting the labels set to always have the same order
+            for label_key in sorted(boxes_abs.labels.keys()):
+                if isinstance(boxes_abs.labels[label_key], aloscene.Labels):
+                    labels.append(boxes_abs.labels[label_key])
             labels = [labels] * len(boxes_abs)
         else:
             labels = [None] * len(boxes_abs)

--- a/aloscene/bounding_boxes_3d.py
+++ b/aloscene/bounding_boxes_3d.py
@@ -502,9 +502,11 @@ class BoundingBoxes3D(aloscene.tensors.AugmentedTensor):
             frame = frame.norm01().cpu().rename(None).permute([1, 2, 0]).detach().contiguous().numpy()
             if isinstance(self.labels, dict):
                 labels_list = []
-                for value in self.labels.values():
-                    labels_list.append(value)
+                # Sorting the labels set to always have the same order
+                for label_key in sorted(self.labels.keys()):
+                    labels_list.append(self.labels[label_key])
                 class_names = []
+                color = []
                 for index in range(len(labels_list[0])):
                     text = []
                     for label in labels_list:
@@ -512,13 +514,16 @@ class BoundingBoxes3D(aloscene.tensors.AugmentedTensor):
                             label.labels_names[int(label[index])] if label.labels_names else str(int(label[index]))
                         )
                     class_names.append(" , ".join(text))
+                    labels_sum = sum([int(label[index]) for label in labels_list])
+                    color.append(self._GLOBAL_COLOR_SET[labels_sum % len(self._GLOBAL_COLOR_SET)])
                 labels = range(len(class_names))
             else:
                 labels = [int(label_value) for label_value in self.labels]
                 class_names = (
-                    self.labels.labels_names if self.labels.labels_names else [int(label) for label in labels]
+                    self.labels.labels_names if self.labels.labels_names else range(len(labels))
                 )
-            draw_3D_box(frame, vertices_3d_proj, class_names=class_names, labels=labels)
+                color = [self._GLOBAL_COLOR_SET[int(label) % len(self._GLOBAL_COLOR_SET)] for label in labels]
+            draw_3D_box(frame, vertices_3d_proj, class_names=class_names, labels=labels, colors=color)
             return View(frame, **kwargs)
         elif mode == "2D":
             enclosing_2d = self.get_enclosing_box_2d(self, cam_intrinsic, cam_extrinsic, frame_size)

--- a/aloscene/bounding_boxes_3d.py
+++ b/aloscene/bounding_boxes_3d.py
@@ -500,8 +500,24 @@ class BoundingBoxes3D(aloscene.tensors.AugmentedTensor):
             )
             # Draw bbox 3d
             frame = frame.norm01().cpu().rename(None).permute([1, 2, 0]).detach().contiguous().numpy()
-            labels = [int(label_value) for label_value in self.labels]
-            class_names = self.labels.labels_names if self.labels.labels_names else [int(label) for label in labels]
+            if isinstance(self.labels, dict):
+                labels_list = []
+                for value in self.labels.values():
+                    labels_list.append(value)
+                class_names = []
+                for index in range(len(labels_list[0])):
+                    text = []
+                    for label in labels_list:
+                        text.append(
+                            label.labels_names[int(label[index])] if label.labels_names else str(int(label[index]))
+                        )
+                    class_names.append(" , ".join(text))
+                labels = range(len(class_names))
+            else:
+                labels = [int(label_value) for label_value in self.labels]
+                class_names = (
+                    self.labels.labels_names if self.labels.labels_names else [int(label) for label in labels]
+                )
             draw_3D_box(frame, vertices_3d_proj, class_names=class_names, labels=labels)
             return View(frame, **kwargs)
         elif mode == "2D":

--- a/aloscene/bounding_boxes_3d.py
+++ b/aloscene/bounding_boxes_3d.py
@@ -472,7 +472,9 @@ class BoundingBoxes3D(aloscene.tensors.AugmentedTensor):
             )
             # Draw bbox 3d
             frame = frame.norm01().cpu().rename(None).permute([1, 2, 0]).detach().contiguous().numpy()
-            draw_3D_box(frame, vertices_3d_proj)
+            labels = [int(label_value) for label_value in self.labels]
+            class_names = self.labels.labels_names if self.labels.labels_names else [int(label) for label in labels]
+            draw_3D_box(frame, vertices_3d_proj, class_names=class_names, labels=labels)
             return View(frame, **kwargs)
         elif mode == "2D":
             enclosing_2d = self.get_enclosing_box_2d(self, cam_intrinsic, cam_extrinsic, frame_size)

--- a/aloscene/renderer/bbox3d.py
+++ b/aloscene/renderer/bbox3d.py
@@ -35,23 +35,23 @@ def _draw_3D_box(image, vertices_2d, color1=None, color2=None, class_names=None,
             color2 = colors[i] ** 2
         # plt.imshow(image)
         # plt.show()
-        for i in range(4):
-            point_1_ = points[2 * i]
-            point_2_ = points[2 * i + 1]
+        for j in range(4):
+            point_1_ = points[2 * j]
+            point_2_ = points[2 * j + 1]
             cv2.line(image, (point_1_[0], point_1_[1]), (point_2_[0], point_2_[1]), color1, 2)
             # plt.imshow(image)
             # plt.show()
 
-        for i in range(4):
-            point_1_ = points[i]
-            point_2_ = points[i + 4]
+        for k in range(4):
+            point_1_ = points[k]
+            point_2_ = points[k + 4]
             cv2.line(image, (point_1_[0], point_1_[1]), (point_2_[0], point_2_[1]), color1, 2)
             # plt.imshow(image)
             # plt.show()
 
-        for i in [0, 1, 4, 5]:
-            point_1_ = points[i]
-            point_2_ = points[i + 2]
+        for l in [0, 1, 4, 5]:
+            point_1_ = points[l]
+            point_2_ = points[l + 2]
             cv2.line(image, (point_1_[0], point_1_[1]), (point_2_[0], point_2_[1]), color1, 2)
             # plt.imshow(image)
             # plt.show()
@@ -78,7 +78,7 @@ def _draw_3D_box(image, vertices_2d, color1=None, color2=None, class_names=None,
                 # (point_1_[0], point_1_[1]),
                 cv2.FONT_HERSHEY_SIMPLEX,
                 0.5,
-                (1.0, 0, 0),
+                color1,
                 1,
                 cv2.LINE_AA,
             )

--- a/aloscene/tensors/augmented_tensor.py
+++ b/aloscene/tensors/augmented_tensor.py
@@ -24,13 +24,14 @@ def _torch_function_get_self(cls, func, types, args, kwargs):
         elif isinstance(a, tuple):
             return _torch_function_get_self(cls, func, types, list(a), kwargs)
     return None
-        
+
 
 class AugmentedTensor(torch.Tensor):
     """Tensor with attached labels"""
 
     # Common dim names that must be aligned to handle label on a Tensor.
     COMMON_DIM_NAMES = ["B", "T"]
+    _GLOBAL_COLOR_SET = np.random.uniform(0, 1, (300, 3))
 
     # Ignore named tansors userwarning.
     ERROR_MSG = "Named tensors and all their associated APIs are an experimental feature and subject to change"
@@ -567,7 +568,7 @@ class AugmentedTensor(torch.Tensor):
 
     @classmethod
     def __torch_function__(cls, func, types, args=(), kwargs=None):
-        
+
         self = _torch_function_get_self(cls, func, types, args, kwargs)
 
         def _merging_frame(args):


### PR DESCRIPTION
Write Labels next to BoundingBoxes3D.

* ***Labels on  BoundingBoxes3D*** : Display on render.
```python
import numpy as np
import torch
from aloscene import Frame, Labels, BoundingBoxes3D, CameraExtrinsic, CameraIntrinsic, BoundingBoxes2D

frame = Frame(np.zeros((3, 500, 500)), normalization="01")
frame.append_cam_intrinsic(CameraIntrinsic(focal_length=721.0, plane_size=frame.HW))
frame.append_cam_extrinsic(CameraExtrinsic(torch.eye(4, dtype=torch.float32)))
label = Labels([1, 0, 2], labels_names=["car", "person", "truck"])
label2 = Labels([1, 1, 0], labels_names=["register", "unknown"])

box3d = BoundingBoxes3D([[15, 30, 400, 20, 16, 18, 1], [0, 0, 200, 80, 46, 18, 0.5], [10, 10, 200, 80, 46, 18, 0.5]])
box3d.append_labels(label, "objects")
box3d.append_labels(label2, "type")
frame.append_boxes3d(box3d)

box2d = BoundingBoxes2D(
    [[300, 350, 50, 50], [300, 300, 200, 200], [350, 350, 200, 200]], boxes_format="xcyc", absolute=True, frame_size=(500, 500)
)
box2d.append_labels(label, "objects")
box2d.append_labels(label2, "type")
frame.append_boxes2d(box2d)

frame.get_view().render()
```

* ***Labels dont render*** : #253 

_____
This pull request includes

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
