### PR TITLE
allow batch_list to batch tensors with different children

### DIFF
--- a/aloscene/__init__.py
+++ b/aloscene/__init__.py
@@ -21,8 +21,8 @@ from .renderer import Renderer
 from typing import Union
 
 
-def batch_list(tensors):
-    return SpatialAugmentedTensor.batch_list(tensors)
+def batch_list(tensors, intersection=False):
+    return SpatialAugmentedTensor.batch_list(tensors, intersection=intersection)
 
 
 _renderer = None

--- a/aloscene/tensors/augmented_tensor.py
+++ b/aloscene/tensors/augmented_tensor.py
@@ -544,7 +544,7 @@ class AugmentedTensor(torch.Tensor):
                     # if we removed all keys, set this child to None
                     if intersection and not labels_dict2list[label_name]:
                         labels_dict2list[label_name] = None
-                elif intersection and len(labels_dict2list[label_name]) != dim_size or (None in labels_dict2list[label_name]):
+                elif intersection and (len(labels_dict2list[label_name]) != dim_size or (None in labels_dict2list[label_name])):
                     labels_dict2list[label_name] = None
                 else:
                     args = list(args)

--- a/aloscene/tensors/augmented_tensor.py
+++ b/aloscene/tensors/augmented_tensor.py
@@ -24,10 +24,12 @@ def _torch_function_get_self(cls, func, types, args, kwargs):
         elif isinstance(a, tuple):
             return _torch_function_get_self(cls, func, types, list(a), kwargs)
     return None
-        
+
 
 class AugmentedTensor(torch.Tensor):
     """Tensor with attached labels"""
+
+    BATCH_LIST_INTERSECT = False
 
     # Common dim names that must be aligned to handle label on a Tensor.
     COMMON_DIM_NAMES = ["B", "T"]
@@ -464,17 +466,22 @@ class AugmentedTensor(torch.Tensor):
             else:
                 for s in range(len(sub_label)):
                     _fillup_dict(dm[s], sub_label[s], dim + 1, target_dim)
-
         _fillup_dict(dict_merge[key], label, 0, target_dim)
 
         return dict_merge
 
     def _merge_tensor(self, n_tensor, tensor_list, func, types, args=(), kwargs=None):
+
+        # do the merge as an intersection between tensors
+        intersection = AugmentedTensor.BATCH_LIST_INTERSECT
+        print("[intersection]", intersection)
+
         """Merge tensors together and their associated labels"""
         labels_dict2list = {}
         # Setup the new structure before to merge
         prop_name_to_value = {}
 
+        dim_size = len(tensor_list)
         for tensor in tensor_list:
 
             for prop in tensor._property_list:
@@ -520,10 +527,21 @@ class AugmentedTensor(torch.Tensor):
         for label_name in labels_dict2list:
             if self._child_property[label_name]["mergeable"]:
                 if isinstance(labels_dict2list[label_name], dict):
-                    for key in labels_dict2list[label_name]:
-                        args = list(args)
-                        args[0] = labels_dict2list[label_name][key]
-                        labels_dict2list[label_name][key] = func(*tuple(args), **kwargs)
+                    for key in list(labels_dict2list[label_name].keys()):
+                        if len(labels_dict2list[label_name][key]) != dim_size:
+                            if intersection:# labels_dict2list[label_name][key] = None
+                                del labels_dict2list[label_name][key]
+                            else:
+                                raise ValueError()
+                        else:
+                            args = list(args)
+                            args[0] = labels_dict2list[label_name][key]
+                            labels_dict2list[label_name][key] = func(*tuple(args), **kwargs)
+                    # if we removed all keys, set this child to None
+                    if intersection and not labels_dict2list[label_name]:
+                        labels_dict2list[label_name] = None
+                elif intersection and len(labels_dict2list[label_name]) != dim_size or (None in labels_dict2list[label_name]):
+                    labels_dict2list[label_name] = None
                 else:
                     args = list(args)
                     args[0] = labels_dict2list[label_name]
@@ -567,7 +585,8 @@ class AugmentedTensor(torch.Tensor):
 
     @classmethod
     def __torch_function__(cls, func, types, args=(), kwargs=None):
-        
+        # print(f"[torch_function] {func.__name__}")
+
         self = _torch_function_get_self(cls, func, types, args, kwargs)
 
         def _merging_frame(args):

--- a/aloscene/tensors/augmented_tensor.py
+++ b/aloscene/tensors/augmented_tensor.py
@@ -530,6 +530,7 @@ class AugmentedTensor(torch.Tensor):
         # Merge all labels together
         for label_name in labels_dict2list:
             if self._child_property[label_name]["mergeable"]:
+
                 if isinstance(labels_dict2list[label_name], dict):
                     for key in list(labels_dict2list[label_name].keys()):
                         if len(labels_dict2list[label_name][key]) != dim_size:
@@ -551,6 +552,11 @@ class AugmentedTensor(torch.Tensor):
                     args[0] = labels_dict2list[label_name]
                     labels_dict2list[label_name] = func(*tuple(args), **kwargs)
                 setattr(n_tensor, label_name, labels_dict2list[label_name])
+            elif (None in labels_dict2list[label_name]):
+                if intersection:
+                    setattr(n_tensor, label_name, None)
+                else:
+                    raise RuntimeError(f"Error during merging. Label '{label_name}' is set for some tensors but not all.")
             else:
                 setattr(n_tensor, label_name, labels_dict2list[label_name])
 

--- a/aloscene/tensors/augmented_tensor.py
+++ b/aloscene/tensors/augmented_tensor.py
@@ -551,11 +551,6 @@ class AugmentedTensor(torch.Tensor):
                     args[0] = labels_dict2list[label_name]
                     labels_dict2list[label_name] = func(*tuple(args), **kwargs)
                 setattr(n_tensor, label_name, labels_dict2list[label_name])
-            elif (None in labels_dict2list[label_name]):
-                if intersection:
-                    setattr(n_tensor, label_name, None)
-                else:
-                    raise RuntimeError(f"Error during merging. Label '{label_name}' is set for some tensors but not all.")
             else:
                 setattr(n_tensor, label_name, labels_dict2list[label_name])
 

--- a/aloscene/tensors/augmented_tensor.py
+++ b/aloscene/tensors/augmented_tensor.py
@@ -474,7 +474,6 @@ class AugmentedTensor(torch.Tensor):
 
         # do the merge as an intersection between tensors
         intersection = AugmentedTensor.BATCH_LIST_INTERSECT
-        print("[intersection]", intersection)
 
         """Merge tensors together and their associated labels"""
         labels_dict2list = {}
@@ -595,8 +594,6 @@ class AugmentedTensor(torch.Tensor):
 
     @classmethod
     def __torch_function__(cls, func, types, args=(), kwargs=None):
-        # print(f"[torch_function] {func.__name__}")
-
         self = _torch_function_get_self(cls, func, types, args, kwargs)
 
         def _merging_frame(args):

--- a/aloscene/tensors/augmented_tensor.py
+++ b/aloscene/tensors/augmented_tensor.py
@@ -533,7 +533,7 @@ class AugmentedTensor(torch.Tensor):
                 if isinstance(labels_dict2list[label_name], dict):
                     for key in list(labels_dict2list[label_name].keys()):
                         if len(labels_dict2list[label_name][key]) != dim_size:
-                            if intersection:# labels_dict2list[label_name][key] = None
+                            if intersection:
                                 del labels_dict2list[label_name][key]
                             else:
                                 raise RuntimeError(f"Error during merging. Some tensors have label '{label_name}' with key '{key}' and some don't")

--- a/aloscene/tensors/spatial_augmented_tensor.py
+++ b/aloscene/tensors/spatial_augmented_tensor.py
@@ -311,7 +311,7 @@ class SpatialAugmentedTensor(AugmentedTensor):
         return tensor
 
     @staticmethod
-    def batch_list(sa_tensors: list, pad_boxes: bool = False, pad_points2d: bool = False):
+    def batch_list(sa_tensors: list, pad_boxes: bool = False, pad_points2d: bool = False, intersection=False):
         """Given a list of Spatial Augmeted tensor of potentially different size (otherwise cat is enough) this method
         will create a new set of frame of same size (the max size across the frames)
         and add to each frame a mask with 1. on the padded area.
@@ -378,7 +378,11 @@ class SpatialAugmentedTensor(AugmentedTensor):
             padded_spatial_tensor = spatial_tensor.pad(h_pad, w_pad, pad_boxes=pad_boxes, pad_points2d=pad_points2d)
             n_padded_list.append(padded_spatial_tensor)
 
+        old_intersect = AugmentedTensor.BATCH_LIST_INTERSECT
+        AugmentedTensor.BATCH_LIST_INTERSECT = intersection
+        print("AugmentedTensor.BATCH_LIST_INTERSECT: ", AugmentedTensor.BATCH_LIST_INTERSECT )
         n_augmented_tensors = torch.cat(n_padded_list, dim=0)
+        AugmentedTensor.BATCH_LIST_INTERSECT = old_intersect
 
         # Set the new mask and tensor buffer filled up with zeros and ones
         # Also, for normalized frames, the zero value is actually different based on the mean/std

--- a/aloscene/tensors/spatial_augmented_tensor.py
+++ b/aloscene/tensors/spatial_augmented_tensor.py
@@ -386,7 +386,7 @@ class SpatialAugmentedTensor(AugmentedTensor):
             padded_spatial_tensor = spatial_tensor.pad(h_pad, w_pad, pad_boxes=pad_boxes, pad_points2d=pad_points2d)
             n_padded_list.append(padded_spatial_tensor)
 
-        # batch the tensors witch torch.cat ; et flag to specify desired behavior of torch.cat
+        # batch the tensors witch torch.cat ; set flag to specify desired behavior of torch.cat
         # necessary because torch.cat cannot accept kwargs (like intersection) that are not in the original signature
         intersect_old_value = AugmentedTensor.BATCH_LIST_INTERSECT
         AugmentedTensor.BATCH_LIST_INTERSECT = intersection

--- a/aloscene/tensors/spatial_augmented_tensor.py
+++ b/aloscene/tensors/spatial_augmented_tensor.py
@@ -325,6 +325,14 @@ class SpatialAugmentedTensor(AugmentedTensor):
             list of spatial augmented tensors within the list
         pad_boxes: bool
             By default, do not rescale the boxes attached to the sptial augmented Tensor (see explanation in boxes2d.pad)
+        pad_point2d: bool
+            By default, False
+        intersection: bool
+            By default, an error is thrown if the tensors do not have the same children.
+                Example1 : two frames from which only one has flow label.
+                Example2 : two frames with different values for baseline property.
+            If intersection is True, the batched tensor will have only children that exist in all original tensors.
+            The properties with different values will be set to None.
 
         Returns
         -----------
@@ -378,11 +386,12 @@ class SpatialAugmentedTensor(AugmentedTensor):
             padded_spatial_tensor = spatial_tensor.pad(h_pad, w_pad, pad_boxes=pad_boxes, pad_points2d=pad_points2d)
             n_padded_list.append(padded_spatial_tensor)
 
-        old_intersect = AugmentedTensor.BATCH_LIST_INTERSECT
+        # batch the tensors witch torch.cat ; et flag to specify desired behavior of torch.cat
+        # necessary because torch.cat cannot accept kwargs (like intersection) that are not in the original signature
+        intersect_old_value = AugmentedTensor.BATCH_LIST_INTERSECT
         AugmentedTensor.BATCH_LIST_INTERSECT = intersection
-        print("AugmentedTensor.BATCH_LIST_INTERSECT: ", AugmentedTensor.BATCH_LIST_INTERSECT )
         n_augmented_tensors = torch.cat(n_padded_list, dim=0)
-        AugmentedTensor.BATCH_LIST_INTERSECT = old_intersect
+        AugmentedTensor.BATCH_LIST_INTERSECT = intersect_old_value
 
         # Set the new mask and tensor buffer filled up with zeros and ones
         # Also, for normalized frames, the zero value is actually different based on the mean/std

--- a/unittest/test_augmented_tensor.py
+++ b/unittest/test_augmented_tensor.py
@@ -1,3 +1,4 @@
+import pytest
 import aloscene
 import torch
 from aloscene import Frame, Disparity, Flow
@@ -8,30 +9,42 @@ def test_batch_list_intersection_property():
     - it is not set in every tensor
     - or it does not have same value in every tensor
     """
+    # case #1: one tensor has None
     f1 = Frame(torch.ones(3,10,10))
     f2 = Frame(torch.ones(3,10,10))
     f1.baseline = 0.5
     f2.baseline = None
     f = aloscene.batch_list([f1, f2], intersection=True)
     assert f.baseline is None
+    with pytest.raises(RuntimeError):
+        f = aloscene.batch_list([f1, f2], intersection=False) # old behavior was to raise a RuntimeError
 
+    # case #2: tensors have different values
     f2.baseline = 1
     f = aloscene.batch_list([f1, f2], intersection=True)
     assert f.baseline is None
+    with pytest.raises(RuntimeError):
+        f = aloscene.batch_list([f1, f2], intersection=False) # old behavior was to raise a RuntimeError
 
 def test_batch_list_intersection_mergeable_child():
     """
     When batching with intersection flag, an unmergeable child should be set to None if:
     - it is not set in every tensor
     """
+    # case #1: one tensor has None
     f1 = Frame(torch.ones(3,10,10))
     f2 = Frame(torch.ones(3,10,10))
     f1.append_disparity(Disparity(torch.ones(1,10,10)))
     f = aloscene.batch_list([f1, f2], intersection=True)
     assert f.disparity is None
+    with pytest.raises(TypeError):
+        f = aloscene.batch_list([f1, f2], intersection=False) # old behavior was to raise a TypeError
 
+    # case #2: both tensors have disparity
     f2.append_disparity(Disparity(torch.ones(1,10,10)))
     f = aloscene.batch_list([f1, f2], intersection=True)
+    assert f.disparity.shape == (2, 1, 10, 10)
+    f = aloscene.batch_list([f1, f2], intersection=False) # old behavior was the same : merge the  disparities
     assert f.disparity.shape == (2, 1, 10, 10)
 
 def test_batch_list_intersection_unmergeable_child():
@@ -42,6 +55,11 @@ def test_batch_list_intersection_unmergeable_child():
     f2 = Frame(torch.ones(3,10,10))
     f1.append_flow(Flow(torch.ones(2,10,10)))
     f = aloscene.batch_list([f1, f2], intersection=True)
+    assert isinstance(f.flow, list)
+    assert len(f.flow) == 2
+    assert f.flow[0].shape == (2, 10, 10)
+    assert f.flow[1] is None
+    f = aloscene.batch_list([f1, f2], intersection=False) # old behavior was the same : stack children in list
     assert isinstance(f.flow, list)
     assert len(f.flow) == 2
     assert f.flow[0].shape == (2, 10, 10)

--- a/unittest/test_augmented_tensor.py
+++ b/unittest/test_augmented_tensor.py
@@ -1,0 +1,48 @@
+import aloscene
+import torch
+from aloscene import Frame, Disparity, Flow
+
+def test_batch_list_intersection_property():
+    """
+    When batching with intersection flag, a property should be set to None if:
+    - it is not set in every tensor
+    - or it does not have same value in every tensor
+    """
+    f1 = Frame(torch.ones(3,10,10))
+    f2 = Frame(torch.ones(3,10,10))
+    f1.baseline = 0.5
+    f2.baseline = None
+    f = aloscene.batch_list([f1, f2], intersection=True)
+    assert f.baseline is None
+
+    f2.baseline = 1
+    f = aloscene.batch_list([f1, f2], intersection=True)
+    assert f.baseline is None
+
+def test_batch_list_intersection_mergeable_child():
+    """
+    When batching with intersection flag, an unmergeable child should be set to None if:
+    - it is not set in every tensor
+    """
+    f1 = Frame(torch.ones(3,10,10))
+    f2 = Frame(torch.ones(3,10,10))
+    f1.append_disparity(Disparity(torch.ones(1,10,10)))
+    f = aloscene.batch_list([f1, f2], intersection=True)
+    assert f.disparity is None
+
+    f2.append_disparity(Disparity(torch.ones(1,10,10)))
+    f = aloscene.batch_list([f1, f2], intersection=True)
+    assert f.disparity.shape == (2, 1, 10, 10)
+
+def test_batch_list_intersection_unmergeable_child():
+    """
+    When batching with intersection flag, an unmergeable child should always be stacked in a list
+    """
+    f1 = Frame(torch.ones(3,10,10))
+    f2 = Frame(torch.ones(3,10,10))
+    f1.append_flow(Flow(torch.ones(2,10,10)))
+    f = aloscene.batch_list([f1, f2], intersection=True)
+    assert isinstance(f.flow, list)
+    assert len(f.flow) == 2
+    assert f.flow[0].shape == (2, 10, 10)
+    assert f.flow[1] is None


### PR DESCRIPTION
Add an argument to `aloscene.batch_list`, allowing to batch tensors with different children or properties with different values. 
Closes #272 

* ***New feature 1*** : Merge with different properties
```python
f1 = Frame(torch.ones(3,10,10))
f2 = Frame(torch.ones(3,10,10))
f1.baseline = 0.5
f2.baseline = 1
f = aloscene.batch_list([f1, f2], intersection=True)
print(f.baseline)
```
Here, the `baseline` property has different values for different tensors. Therefore, the property baseline of the batched tensors has `baseline` set to `None`.

* ***New feature 2*** : Merge with different mergeable children
```python
f1 = Frame(torch.ones(3,10,10))
f2 = Frame(torch.ones(3,10,10))
f1.append_disparity(Disparity(torch.ones(1,10,10)))
f = aloscene.batch_list([f1, f2], intersection=True)
print(f.disparity)
```
Only one of the two frames has a disparity child, therefore the batched tensor will have `disparity` set to `None`

*Note: this will not drop unmergeable children, because by definition they allow that some tensors have `None` values for a child before merging* 
_____
This pull request includes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
