### PR TITLE
Alobugdays : Fix index of element to get in tutorials

### DIFF
--- a/tutorials/2-frame.py
+++ b/tutorials/2-frame.py
@@ -4,7 +4,7 @@ from alodataset import WaymoDataset, Split
 waymo_dataset = WaymoDataset(split=Split.VAL, cameras=["front"], labels=["gt_boxes_2d"])
 
 # Get a frame at some position in the dataset
-data = waymo_dataset.get(42)
+data = waymo_dataset.get(2)
 
 # The frame object is a special type of Tensor (Labeled Tensor) with special attributes and labels
 # attached to it

--- a/tutorials/2.1-frame.py
+++ b/tutorials/2.1-frame.py
@@ -1,7 +1,7 @@
 from aloscene.renderer import View
 from alodataset import WaymoDataset, Split
 
-frame = WaymoDataset(split=Split.VAL, cameras=["front"], labels=["gt_boxes_2d"]).get(42)["front"]
+frame = WaymoDataset(split=Split.VAL, cameras=["front"], labels=["gt_boxes_2d"]).get(2)["front"]
 
 ######
 # Here are some example of the operations that can be done on a frame

--- a/tutorials/2.2-frame.py
+++ b/tutorials/2.2-frame.py
@@ -7,7 +7,7 @@ frame = WaymoDataset(
     cameras=["front"],
     labels=["gt_boxes_2d"],
     sequence_size=2,  #  --> Let's use sequence of two frame
-).get(42)["front"]
+).get(2)["front"]
 
 ######
 # The frame tensors and its labels

--- a/tutorials/2.3-frame.py
+++ b/tutorials/2.3-frame.py
@@ -3,7 +3,7 @@ from alodataset import WaymoDataset, Split
 import torch
 
 frame = WaymoDataset(split=Split.VAL, cameras=["front"], labels=["gt_boxes_2d"], sequence_size=1,).get(  #
-    42
+    2
 )["front"]
 
 ######

--- a/tutorials/3-boxes.py
+++ b/tutorials/3-boxes.py
@@ -3,7 +3,7 @@ from alodataset import WaymoDataset, Split
 import torch
 
 frames = WaymoDataset(split=Split.VAL, cameras=["front"], labels=["gt_boxes_2d"], sequence_size=2,).get(  #
-    42
+    2
 )["front"]
 
 ######

--- a/tutorials/3.1-boxes.py
+++ b/tutorials/3.1-boxes.py
@@ -3,7 +3,7 @@ from alodataset import WaymoDataset, Split
 import torch
 
 frames = WaymoDataset(split=Split.VAL, cameras=["front"], labels=["gt_boxes_2d"], sequence_size=2,).get(
-    42
+    2
 )["front"]
 
 ######


### PR DESCRIPTION

* ***Fix index of element to get in tutorials*** : When downloading a sample, some files in tutorials would raise an error because the index of the element to get does not exist: `waymo_dataset.get(42)`. This PR simply replace the index by 2.

_____
This pull request includes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
