### PR TITLE
fix cat for tuple of augmented tensor

### DIFF
--- a/aloscene/tensors/augmented_tensor.py
+++ b/aloscene/tensors/augmented_tensor.py
@@ -571,7 +571,7 @@ class AugmentedTensor(torch.Tensor):
         self = _torch_function_get_self(cls, func, types, args, kwargs)
 
         def _merging_frame(args):
-            if len(args) >= 1 and isinstance(args[0], list):
+            if len(args) >= 1 and isinstance(args[0], (list, tuple)):
                 for el in args[0]:
                     if isinstance(el, cls):
                         return True


### PR DESCRIPTION
Fix the merging of tensor to allow `torch.cat` to accept a `tuple` of `AugmentedTensor`. 
Close #306 

* ***Fix bug 1*** : accept tuples of `AugmentedTensor` in `torch.cat`

_____
This pull request includes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
