### PR TITLE
kumler-bauer now support distortion coefficients in pixel instead of in meter

### DIFF
--- a/aloscene/depth.py
+++ b/aloscene/depth.py
@@ -292,7 +292,7 @@ class Depth(aloscene.tensors.SpatialAugmentedTensor):
                 focal_length = focal_length * theta * dist_coef / r.abs()
             elif projection == "kumler_bauer":
                 focal_length = (
-                    distortion[0] * torch.sin(distortion[1] * theta) * focal_length / (distortion[2] * r.abs())
+                    distortion[0] * torch.sin(distortion[1] * theta) / r.abs()
                 )
 
             # find points behind camera

--- a/aloscene/utils/depth_utils.py
+++ b/aloscene/utils/depth_utils.py
@@ -25,8 +25,10 @@ def coords2rtheta(
     h, w = size
     focal = K.focal_length[..., 0]
     principal_point = K.principal_points[..., :]
+    valid_names = []
     for name in K.names:
         if name in ["B", "T"]:
+            valid_names.append(name)
             focal = focal[0, ...]
             principal_point = principal_point[0, ...]
     principal_point = principal_point[:, None, None]
@@ -36,6 +38,8 @@ def coords2rtheta(
     coords = coords - principal_point
     r_d = coords[:2, ...] * coords[:2, ...]
     r_d = torch.sqrt(torch.sum(r_d, dim=0, keepdim=True))
+    for _ in range(len(valid_names)):
+        r_d = r_d.unsqueeze(0)
 
     if projection == "pinhole":
         theta = torch.atan(r_d / focal)
@@ -45,14 +49,16 @@ def coords2rtheta(
     elif projection == "kumler_bauer":
         # distortion [k1, k2]
         assert (
-            isinstance(distortion, Sequence) and len(distortion) == 2
-        ), f"Kumler-Bauer projection needs 2 distortion coefficients (alpha (in pixel), beta), found {len(distortion)}"
-        theta = torch.arcsin(r_d / distortion[0]) / distortion[1]
+            isinstance(distortion, (Sequence, torch.Tensor))
+        ), f"Kumler-Bauer projection needs to be Sequence or torch.Tensor. Found {type(distortion)}"
+        k1 = distortion[..., 0][..., None, None, None]
+        k2 = distortion[..., 1][..., None, None, None]
+        theta = torch.arcsin(r_d / k1) / k2
     else:
         raise NotImplementedError
 
-    theta = AugmentedTensor(theta, names=("C", "H", "W"))
-    r_d = AugmentedTensor(r_d, names=("C", "H", "W"))
+    theta = AugmentedTensor(theta, names=valid_names + ["C", "H", "W"])
+    r_d = AugmentedTensor(r_d, names=valid_names + ["C", "H", "W"])
 
     return r_d, theta
 

--- a/aloscene/utils/depth_utils.py
+++ b/aloscene/utils/depth_utils.py
@@ -43,12 +43,11 @@ def coords2rtheta(
         dist_coef = distortion[0] if isinstance(distortion, Sequence) else distortion
         theta = r_d / (focal * dist_coef)
     elif projection == "kumler_bauer":
-        # distortion [k1, k2, focal_meter]
+        # distortion [k1, k2]
         assert (
-            isinstance(distortion, Sequence) and len(distortion) == 3
-        ), "Kumler-Bauer projection needs 3 distortion coefficients (alpha, beta, focal in meter)"
-        fm = distortion[2]
-        theta = torch.arcsin(fm / distortion[0] * r_d / focal) / distortion[1]
+            isinstance(distortion, Sequence) and len(distortion) == 2
+        ), f"Kumler-Bauer projection needs 2 distortion coefficients (alpha (in pixel), beta), found {len(distortion)}"
+        theta = torch.arcsin(r_d / distortion[0]) / distortion[1]
     else:
         raise NotImplementedError
 

--- a/aloscene/utils/depth_utils.py
+++ b/aloscene/utils/depth_utils.py
@@ -27,7 +27,7 @@ def coords2rtheta(
     principal_point = K.principal_points[..., :]
     valid_names = []
     for name in K.names:
-        if name in ["B", "T"]:
+        if name in {"B", "T"}:
             valid_names.append(name)
             focal = focal[0, ...]
             principal_point = principal_point[0, ...]
@@ -44,22 +44,22 @@ def coords2rtheta(
     if projection == "pinhole":
         theta = torch.atan(r_d / focal)
     elif projection == "equidistant":
-        dist_coef = distortion[0] if isinstance(distortion, Sequence) else distortion
+        dist_coef = distortion[0] if isinstance(distortion, (Sequence, torch.Tensor)) else distortion
         theta = r_d / (focal * dist_coef)
     elif projection == "kumler_bauer":
-        # distortion [k1, k2]
-        assert (
-            isinstance(distortion, (Sequence, torch.Tensor))
+        assert isinstance(
+            distortion, (list, torch.Tensor)
         ), f"Kumler-Bauer projection needs to be Sequence or torch.Tensor. Found {type(distortion)}"
-        k1 = distortion[..., 0][..., None, None, None]
-        k2 = distortion[..., 1][..., None, None, None]
+        if isinstance(distortion, torch.Tensor):
+            k1, k2 = distortion[..., 0, None, None, None], distortion[..., 1, None, None, None]
+        else:
+            k1, k2 = distortion[0], distortion[1]
         theta = torch.arcsin(r_d / k1) / k2
     else:
         raise NotImplementedError
 
     theta = AugmentedTensor(theta, names=valid_names + ["C", "H", "W"])
     r_d = AugmentedTensor(r_d, names=valid_names + ["C", "H", "W"])
-
     return r_d, theta
 
 


### PR DESCRIPTION

General description of your pull request with the list of new features and/or bugs.

* ***New feature 1*** : Kumler-bauer distortion coefficients are now in pixel instead of meter. This is more logical with aloception computation because we work alot on image plan, it's too complicated to have a coefficient in meter. Since now, `distortion ` property in case of `kumler_bauer` only needs 2 elements instead of 3 in actual version.
```python
import numpy as np
from aloscene import Frame

data = np.random.uniform(size=(3, 1024, 1024))
frame = Frame(data, names=("C", "H", "W"), projection="kumler_bauer", distortion=[0.1, 0.1])

```
_____
This pull request includes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
