### PR TITLE
Fix camera_calibe to solve boxes 3d wrong display

### DIFF
--- a/aloscene/camera_calib.py
+++ b/aloscene/camera_calib.py
@@ -158,8 +158,8 @@ class CameraIntrinsic(AugmentedTensor):
         pad_top = offset_y[0] * frame_size[0]
         pad_left = offset_x[0] * frame_size[1]
         cam_intrinsic = self.clone()
-        cam_intrinsic[..., 0, 2] += pad_top
-        cam_intrinsic[..., 1, 2] += pad_left
+        cam_intrinsic[..., 0, 2] += pad_left
+        cam_intrinsic[..., 1, 2] += pad_top
         return cam_intrinsic
 
     def get_view(self, *args, **kwargs):

--- a/aloscene/tensors/spatial_augmented_tensor.py
+++ b/aloscene/tensors/spatial_augmented_tensor.py
@@ -557,7 +557,7 @@ class SpatialAugmentedTensor(AugmentedTensor):
         except AttributeError:
             return label
 
-    def _pad(self, offset_y: tuple, offset_x: tuple, **kwargs):
+    def _pad(self, offset_y: tuple, offset_x: tuple, value=0, **kwargs):
         """Pad `self` based on the given offset
 
         Parameters


### PR DESCRIPTION
camera_calib.py :
There was just two misplaced variables in the cam_intrinsic update.

spatial_augmented_tensor.py :
I had to add this value=0 argument to workaround a bug that may be fixed now.