### PR TITLE
Added title to get_view()

### DIFF
--- a/aloscene/renderer/renderer.py
+++ b/aloscene/renderer/renderer.py
@@ -4,8 +4,6 @@ import math
 import matplotlib.pyplot as plt
 import matplotlib
 from abc import ABC, abstractmethod
-import numpy as np
-import cv2
 
 
 def adapt_text_size_to_frame(size, frame_size):
@@ -93,14 +91,16 @@ class View(object):
         if location is not None:
             plt.figure(figsize=figsize, tight_layout=True)
             plt.imshow(self.image)
-            plt.title("Frame" if self.title is None else self.title, self.image[:, :, ::-1])
+            if self.title is not None:
+                plt.title(self.title)
             plt.savefig(location)
             plt.close()
 
         if method == self.MATPLOTLIB:
             plt.figure(figsize=figsize, tight_layout=True)
             plt.imshow(self.image)
-            plt.title("Frame" if self.title is None else self.title, self.image[:, :, ::-1])
+            if self.title is not None:
+                plt.title(self.title)
             plt.show()
             plt.close()
 

--- a/aloscene/renderer/renderer.py
+++ b/aloscene/renderer/renderer.py
@@ -93,12 +93,14 @@ class View(object):
         if location is not None:
             plt.figure(figsize=figsize, tight_layout=True)
             plt.imshow(self.image)
+            plt.title("Frame" if self.title is None else self.title, self.image[:, :, ::-1])
             plt.savefig(location)
             plt.close()
 
         if method == self.MATPLOTLIB:
             plt.figure(figsize=figsize, tight_layout=True)
             plt.imshow(self.image)
+            plt.title("Frame" if self.title is None else self.title, self.image[:, :, ::-1])
             plt.show()
             plt.close()
 

--- a/aloscene/tensors/spatial_augmented_tensor.py
+++ b/aloscene/tensors/spatial_augmented_tensor.py
@@ -130,7 +130,7 @@ class SpatialAugmentedTensor(AugmentedTensor):
         """
         _views = [v for v in views if isinstance(v, View)]
         if len(_views) > 0:
-            return View(Renderer.get_grid_view(_views, grid_size=None, cell_grid_size=size, **kwargs),title=title)
+            return View(Renderer.get_grid_view(_views, grid_size=None, cell_grid_size=size, **kwargs), title=title)
 
         # Include type
         include_type = [

--- a/aloscene/tensors/spatial_augmented_tensor.py
+++ b/aloscene/tensors/spatial_augmented_tensor.py
@@ -110,7 +110,7 @@ class SpatialAugmentedTensor(AugmentedTensor):
     def append_cam_extrinsic(self, cam_extrinsic: CameraExtrinsic):
         self._append_child("cam_extrinsic", cam_extrinsic)
 
-    def get_view(self, views: list = [], exclude=[], size=None, grid_size=None, **kwargs):
+    def get_view(self, views: list = [], exclude=[], size=None, grid_size=None, title=None, **kwargs):
         """Render the spatial augmented tensor.
 
         Parameters
@@ -130,7 +130,7 @@ class SpatialAugmentedTensor(AugmentedTensor):
         """
         _views = [v for v in views if isinstance(v, View)]
         if len(_views) > 0:
-            return View(Renderer.get_grid_view(_views, grid_size=None, cell_grid_size=size, **kwargs))
+            return View(Renderer.get_grid_view(_views, grid_size=None, cell_grid_size=size, **kwargs),title=title)
 
         # Include type
         include_type = [
@@ -194,7 +194,7 @@ class SpatialAugmentedTensor(AugmentedTensor):
             grid_size = None
 
         view = Renderer.get_grid_view(n_views, grid_size=grid_size, cell_grid_size=size, **kwargs)
-        return View(view)
+        return View(view, title=title)
 
     def relative_to_absolute(self, x, dim, assert_integer=False):
         dim = dim.lower()


### PR DESCRIPTION
- ***New feature 1*** : Added title to frames displayed with get_view()

Added a "title" argument to the get_view() method to be able to directly input a title for your display .  
  `        frames.get_view(title="test").render()
  `

- ***New feature 2*** : Added a default title to Matplotlib viewer
If you use the Matplotlib viewer (default) and don't pass a title, "Frame" is the default title for the display (copy of OpenCV viewer behavior)
`        frames.get_view().render()
`



This pull request includes

- [ ]  Bug fix (non-breaking change which fixes an issue)
- [X]  New feature (non-breaking change which adds functionality)
- [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ]  This change requires a documentation update
