### PR TITLE
thomas/depth-smart-resize

### DIFF
--- a/aloscene/depth.py
+++ b/aloscene/depth.py
@@ -1,20 +1,14 @@
+import numpy as np
+import matplotlib
+import torch
 from torchvision.transforms import InterpolationMode
 from torchvision.transforms import functional as F
-
-from logging import warning
-from shutil import ExecError
-import matplotlib
-from matplotlib.pyplot import sca
-import torch
 from typing import *
-import warnings
+
 import aloscene
 from aloscene import Mask
 from aloscene.renderer import View
 from aloscene.utils.depth_utils import coords2rtheta, add_colorbar
-import numpy as np
-from typing import Union, Tuple
-
 from aloscene.io.depth import load_depth
 
 

--- a/aloscene/depth.py
+++ b/aloscene/depth.py
@@ -471,21 +471,18 @@ class Depth(aloscene.tensors.SpatialAugmentedTensor):
         w = self.relative_to_absolute(size[1], "w", assert_integer=False)
         if (kwargs.pop("pool_depth", False) is True) and (self.H > h):
             kernel_size = 1
-            pool_level = 1
-            while self.H // (kernel_size + 1) > h:
+            while self.H // (kernel_size + 1) >= h:
                 kernel_size = kernel_size + 1
-                if self.H % kernel_size == 0:
-                    pool_level = kernel_size
             if not self.is_absolute:  # if we're working with inverse depth, use maxpool over minpool
-                self = torch.nn.functional.max_pool2d(self.rename(None), pool_level).reset_names()
+                self = torch.nn.functional.max_pool2d(self.rename(None), kernel_size).reset_names()
             else:
-                self = -torch.nn.functional.max_pool2d(-self.rename(None), pool_level).reset_names()
+                self = -torch.nn.functional.max_pool2d(-self.rename(None), kernel_size).reset_names()
             return F.resize(self.rename(None), (h, w), interpolation=interpolation).reset_names()
         elif (kwargs.pop("pool_depth_2", False) is True) and (self.H > h):
             pool_level = h // (h * 2) + 1
             inter_size = pool_level * (h * 2)
             inter_size = (inter_size, inter_size)
-            self = F.resize(self.rename(None), inter_size, interpolation=interpolation).reset_name()
+            self = F.resize(self.rename(None), inter_size, interpolation=interpolation).reset_names()
             if self.is_absolute:
                 return -torch.nn.functional.max_pool2d(-self.rename(None), pool_level * 2).reset_names()
             else:

--- a/aloscene/depth.py
+++ b/aloscene/depth.py
@@ -465,7 +465,7 @@ class Depth(aloscene.tensors.SpatialAugmentedTensor):
     def _resize(self, size, interpolation=InterpolationMode.NEAREST, **kwargs):
         h = self.relative_to_absolute(size[0], "h", assert_integer=False)
         w = self.relative_to_absolute(size[1], "w", assert_integer=False)
-        if (kwargs.pop("pool_depth_2", False) is True) and (self.H > h):
+        if (kwargs.pop("pool_depth", False) is True) and (self.H > h):
             kernel_size = 1
             while self.H // (kernel_size + 1) > h:
                 kernel_size = kernel_size + 1
@@ -474,7 +474,7 @@ class Depth(aloscene.tensors.SpatialAugmentedTensor):
             else:
                 self = -torch.nn.functional.max_pool2d(-self.rename(None), kernel_size).reset_names()
             return F.resize(self.rename(None), (h, w), interpolation=interpolation).reset_names()
-        elif (kwargs.pop("pool_depth", False) is True) and (self.H > h):
+        elif (kwargs.pop("pool_depth_2", False) is True) and (self.H > h):
             pool_level = h // (h * 2) + 1
             inter_size = pool_level * (h * 2)
             inter_size = (inter_size, inter_size)

--- a/aloscene/depth.py
+++ b/aloscene/depth.py
@@ -465,7 +465,7 @@ class Depth(aloscene.tensors.SpatialAugmentedTensor):
     def _resize(self, size, interpolation=InterpolationMode.NEAREST, **kwargs):
         h = self.relative_to_absolute(size[0], "h", assert_integer=False)
         w = self.relative_to_absolute(size[1], "w", assert_integer=False)
-        if (kwargs.pop("pool_depth", False) is True) and (self.H > h):
+        if (kwargs.pop("pool_depth_2", False) is True) and (self.H > h):
             kernel_size = 1
             while self.H // (kernel_size + 1) > h:
                 kernel_size = kernel_size + 1
@@ -473,4 +473,15 @@ class Depth(aloscene.tensors.SpatialAugmentedTensor):
                 self = torch.nn.functional.max_pool2d(self.rename(None), kernel_size).reset_names()
             else:
                 self = -torch.nn.functional.max_pool2d(-self.rename(None), kernel_size).reset_names()
-        return F.resize(self.rename(None), (h, w), interpolation=interpolation).reset_names()
+            return F.resize(self.rename(None), (h, w), interpolation=interpolation).reset_names()
+        elif (kwargs.pop("pool_depth", False) is True) and (self.H > h):
+            pool_level = h // (h * 2) + 1
+            inter_size = pool_level * (h * 2)
+            inter_size = (inter_size, inter_size)
+            self = F.resize(self.renome(None), inter_size, interpolation=interpolation).reset_name()
+            if self.is_absolute:
+                return -torch.nn.functional.max_pool2d(-self.rename(None), pool_level * 2).reset_names()
+            else:
+                return torch.nn.functional.max_pool2d(self.rename(None), pool_level * 2).reset_names()
+        else:
+            return F.resize(self.rename(None), (h, w), interpolation=interpolation).reset_names()

--- a/aloscene/depth.py
+++ b/aloscene/depth.py
@@ -231,7 +231,11 @@ class Depth(aloscene.tensors.SpatialAugmentedTensor):
         intrinsic = camera_intrinsic if camera_intrinsic is not None else self.cam_intrinsic
         projection = projection if projection is not None else self.projection
         distortion = distortion if distortion is not None else self.distortion
-        assert projection in ["pinhole", "equidistant", "kumler_bauer"], "Only pinhole, equidistant and kumler_bauer are supported."
+        assert projection in [
+            "pinhole",
+            "equidistant",
+            "kumler_bauer",
+        ], "Only pinhole, equidistant and kumler_bauer are supported."
 
         # if self is not planar depth, we must convert to planar depth before projecting to 3d points
         if self.is_planar:
@@ -467,18 +471,21 @@ class Depth(aloscene.tensors.SpatialAugmentedTensor):
         w = self.relative_to_absolute(size[1], "w", assert_integer=False)
         if (kwargs.pop("pool_depth", False) is True) and (self.H > h):
             kernel_size = 1
+            pool_level = 1
             while self.H // (kernel_size + 1) > h:
                 kernel_size = kernel_size + 1
+                if self.H % kernel_size == 0:
+                    pool_level = kernel_size
             if not self.is_absolute:  # if we're working with inverse depth, use maxpool over minpool
-                self = torch.nn.functional.max_pool2d(self.rename(None), kernel_size).reset_names()
+                self = torch.nn.functional.max_pool2d(self.rename(None), pool_level).reset_names()
             else:
-                self = -torch.nn.functional.max_pool2d(-self.rename(None), kernel_size).reset_names()
+                self = -torch.nn.functional.max_pool2d(-self.rename(None), pool_level).reset_names()
             return F.resize(self.rename(None), (h, w), interpolation=interpolation).reset_names()
         elif (kwargs.pop("pool_depth_2", False) is True) and (self.H > h):
             pool_level = h // (h * 2) + 1
             inter_size = pool_level * (h * 2)
             inter_size = (inter_size, inter_size)
-            self = F.resize(self.renome(None), inter_size, interpolation=interpolation).reset_name()
+            self = F.resize(self.rename(None), inter_size, interpolation=interpolation).reset_name()
             if self.is_absolute:
                 return -torch.nn.functional.max_pool2d(-self.rename(None), pool_level * 2).reset_names()
             else:


### PR DESCRIPTION
Implements a pooling resize option to Depth.
When downsampled, the depth is first [max/min]pooled before resizing to desired size using the NEAREST interpolation.

_____
This pull request includes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
