### PR TITLE
new: real images augmentation

### DIFF
--- a/alodataset/transforms.py
+++ b/alodataset/transforms.py
@@ -1095,7 +1095,7 @@ class RandomFlowMotionBlur(AloTransform):
         if self.rand:
             return (random.random(),)
         else:
-            return self.intensity
+            return (self.intensity,)
 
     def set_params(self, intensity):
         self.intensity = intensity

--- a/alodataset/transforms.py
+++ b/alodataset/transforms.py
@@ -1081,23 +1081,35 @@ class RandomFlowMotionBlur(AloTransform):
             intensity=None,
             **kwargs,
             ):
-        if intensity is not None:
-            print(f"Intensity is set to {intensity}, its value will no more be random.")
-        self.rand = intensity is None
-        super().__init__(**kwargs)
+        self.rand = True
+        if isinstance(intensity, float):
+            self.rand = False
+        elif isinstance(intensity, list):
+            assert all([isinstance(x, float) for x in intensity])
+            assert intensity[0] < intensity[1]
+            assert len(intensity) == 2
+        else:
+            raise RuntimeError("Unknown intensity type")
 
         self.intensity = intensity
         self.subframes = subframes
         self.flow_model = flow_model
         self.model_kwargs = model_kwargs
+        super().__init__(**kwargs)
 
     def sample_params(self):
-        if self.rand:
-            return (random.random(),)
-        else:
+        if isinstance(self.intensity, float):
             return (self.intensity,)
+        elif isinstance(self.intensity, list):
+            intensity = random.random()
+            min_, max_ = self.intensity
+            intensity = intensity * (max_ - min_) + self.intensity[0]
+            return (intensity,)
+        else:
+            raise RuntimeError("Unknown intensity type")
 
     def set_params(self, intensity):
+        print(intensity)
         self.intensity = intensity
 
     def _get_flow_model_kwargs(self, frame1, frame2):

--- a/alodataset/transforms.py
+++ b/alodataset/transforms.py
@@ -1081,10 +1081,11 @@ class RandomFlowMotionBlur(AloTransform):
             intensity=None,
             **kwargs,
             ):
-        super().__init__(**kwargs)
         if intensity is not None:
             print(f"Intensity is set to {intensity}, its value will no more be random.")
         self.rand = intensity is None
+        super().__init__(**kwargs)
+
         self.intensity = intensity
         self.subframes = subframes
         self.flow_model = flow_model

--- a/alodataset/transforms.py
+++ b/alodataset/transforms.py
@@ -1009,8 +1009,6 @@ class RandomMotionBlurV2(AloTransform):
 
     @torch.no_grad()
     def apply(self, frame):
-        self.v_filter_size, self.h_filter_size = 10, 10
-
         # NORM 255 IS MANDATORY, CUDA ERRORS OCCUR OTHERWISE
         blured = frame.clone().norm255().as_tensor()
 

--- a/alodataset/transforms.py
+++ b/alodataset/transforms.py
@@ -958,7 +958,7 @@ class RandomMotionBlur(AloTransform):
         return frame_
 
 
-class RandomMotionBlurV2(AloTransform):
+class RandomFocusBlurV2(AloTransform):
     """Randomly introduces motion blur.
     
     Parameters
@@ -1026,7 +1026,7 @@ class RandomMotionBlurV2(AloTransform):
         return blured
 
 
-class RandomMotionBlurV3(RandomMotionBlurV2):
+class RandomFocusBlurV3(RandomFocusBlurV2):
     @staticmethod
     def h_trans(frame, size):
         c, h, _ = frame.shape

--- a/alodataset/transforms.py
+++ b/alodataset/transforms.py
@@ -1109,7 +1109,6 @@ class RandomFlowMotionBlur(AloTransform):
             raise RuntimeError("Unknown intensity type")
 
     def set_params(self, intensity):
-        print(intensity)
         self.intensity = intensity
 
     def _get_flow_model_kwargs(self, frame1, frame2):

--- a/aloscene/camera_calib.py
+++ b/aloscene/camera_calib.py
@@ -77,7 +77,8 @@ class CameraIntrinsic(AugmentedTensor):
 
     def __init__(self, x=None, *args, **kwargs):
         if x is not None:
-            assert x.shape[-2] == 3 and x.shape[-1] == 4
+            assert x.shape[-1] == 4
+            assert x.shape[-2] == 3 or x.shape[-2] == 4
         super().__init__(x)
 
     @property


### PR DESCRIPTION
* ***New feature*** : 3 different implementations of focus blur augmentation

```python
from alodataset.transforms import RandomFocusBlur, RandomFocusBlurV2, RandomFocusBlurV3

import aloscene
import torch

frame = aloscene.Frame(torch.rand((3, 300, 300)))
blured_frame1 = RandomFocusBlur()(frame)
blured_frame2 = RandomFocusBlurV2()(frame)
blured_frame3 = RandomFocusBlurV3()(frame)

```

* ***New feature*** : Motion blur augmentation from optical flow
```python
## Motion blur from RAFT-flow
from alonet.raft.raft import RAFT

flow_model = RAFT(weights="raft-things")
flow_model = model.eval()

frame_t0_t1 = aloscene.Frame(torch.ones((2, 3, 300, 300)), names=tuple("TCHW"))
frame_t0 = frame_t0_t1[0]
frame_t1 = frame_t0_t1[1]

blured_t1 = RandomFlowMotionBlur(flow_model=flow_model)(frame_t1, p_frame=frame_t0)
blured_t1.get_view().render()

## Motion blur from ground truth optical flow
flow = aloscene.Flow(torch.ones((2, 300, 300)))
blured_t1 = RandomFlowMotionBlur()(frame_t1, flow=flow)
blured_t1.get_view().render()

``` 

* ***New feature*** : Random corner masking augmentation
```python
from alodataset.transforms import RandomCornersMask
import aloscene
import torch

frame = aloscene.Frame(torch.ones((3, 300, 300)))
randomly_masked_frame = RandomCornersMask()(frame)

```


* ***Fix bug X*** : `CameraIntrinsic` initialization with a shape of 4x4 was not possible using `__init__`
_____
This pull request includes

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
