### PR TITLE
normalizing frames with custom mean_std instead of defaulting to resnet

### DIFF
--- a/aloscene/frame.py
+++ b/aloscene/frame.py
@@ -520,13 +520,22 @@ class Frame(aloscene.tensors.SpatialAugmentedTensor):
         >>> frame_custom_norm = frame.norm_resnet(name="custom")
         """
         if name == "resnet":
-            return self.mean_std_norm(mean=self._resnet_mean_std[0], std=self._resnet_mean_std[1], name="resnet")
+            return self.norm_resnet()
         elif mean_std is not None and len(mean_std) == 2:
             return self.mean_std_norm(mean=mean_std[0], std=mean_std[1], name=name)
         elif self.mean_std is not None:
             return self.mean_std_norm(mean=self.mean_std[0], std=self.mean_std[1], name=name)
         else:
             raise Exception("Please pass a mean_std tuple or use the resnet norm")
+
+    def norm_resnet(self) -> Frame:
+        """Normalized the current frame based on the normalized use on resnet on pytorch. This method will
+        simply call `frame.mean_std_norm()` with the resnet mean/std and the name `resnet`.
+        Examples
+        --------
+        >>> frame_resnet = frame.norm_resnet()
+        """
+        return self.mean_std_norm(mean=self._resnet_mean_std[0], std=self._resnet_mean_std[1], name="resnet")
 
     def __get_view__(self, title=None):
         """Create a view of the frame"""


### PR DESCRIPTION
* ***Replaced norm_resnet by norm_meanstd*** : 
You can now normalize frame with custom mean_std instead of defaulting to resnet.
Either you pass the mean_std at instanciation or you pass it as a parameter to the norm_meanstd function : 
```python
import torch
import aloscene

x=torch.rand(3,600,600)
x=aloscene.Frame(x,mean_std=((0.333,0.333,0.333),(0.333,0.333,0.333)))

x=x.norm_meanstd()
print("normalization de x ",x.normalization)
print("Mean_std de x",x.mean_std)

x=x.norm_meanstd(name="resnet")
print("normalization de x ",x.normalization)
print("Mean_std de x",x.mean_std)

x=x.norm_meanstd(mean_std=((0.440,0.220,0.880),(0.333,0.333,0.333)), name="my_norm")
print("normalization de x ",x.normalization)
print("Mean_std de x",x.mean_std)
```

* ***Output*** : 
```python
normalization de x  None
Mean_std de x ((0.333, 0.333, 0.333), (0.333, 0.333, 0.333))
normalization de x  resnet
Mean_std de x ((0.485, 0.456, 0.406), (0.229, 0.224, 0.225))
normalization de x  my_norm
Mean_std de x ((0.44, 0.22, 0.88), (0.333, 0.333, 0.333))

```

_____
This pull request includes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
