### PR TITLE
fixed the mean_std_norm function

### DIFF
--- a/aloscene/frame.py
+++ b/aloscene/frame.py
@@ -488,9 +488,12 @@ class Frame(aloscene.tensors.SpatialAugmentedTensor):
         tensor = self
 
         if mean is None or std is None :
-            mean=tensor.mean_std[0]
-            std=tensor.mean_std[1]
-            name="default"
+            if tensor.mean_std is not None :
+                mean=tensor.mean_std[0]
+                std=tensor.mean_std[1]
+                name="default"
+            else :
+                raise Exception("Tensor doesn't have stored mean_std parameters. Please pass these parameters to the function")
 
         mean_tensor, std_tensor = self._get_mean_std_tensor(
             tensor.shape, tensor.names, (mean,std), device=tensor.device

--- a/aloscene/frame.py
+++ b/aloscene/frame.py
@@ -474,7 +474,7 @@ class Frame(aloscene.tensors.SpatialAugmentedTensor):
         tensor.normalization = "minmax_sym"
         return tensor
 
-    def mean_std_norm(self, mean=None, std=None, name=None) -> Frame:
+    def mean_std_norm(self, mean, std, name) -> Frame:
         """Normnalize the tensor from the current tensor
         normalization to the expected resnet normalization (x - mean) / std
         with x normalized with value between 0 and 1.
@@ -486,14 +486,6 @@ class Frame(aloscene.tensors.SpatialAugmentedTensor):
         >>> normalized_frame = frame.mean_std_norm(mean, std, "my_norm")
         """
         tensor = self
-
-        if mean is None or std is None :
-            if tensor.mean_std is not None :
-                mean=tensor.mean_std[0]
-                std=tensor.mean_std[1]
-                name="default"
-            else :
-                raise Exception("Tensor doesn't have stored mean_std parameters. Please pass these parameters to the function")
 
         mean_tensor, std_tensor = self._get_mean_std_tensor(
             tensor.shape, tensor.names, (mean,std), device=tensor.device

--- a/aloscene/frame.py
+++ b/aloscene/frame.py
@@ -466,7 +466,7 @@ class Frame(aloscene.tensors.SpatialAugmentedTensor):
         elif tensor.normalization == "255":
             tensor = 2 * (tensor / 255.0) - 1.0
         elif tensor.mean_std is not None:
-            tensor=tensor.norm01()
+            tensor = tensor.norm01()
             tensor = 2 * tensor - 1.0
         else:
             raise Exception(f"Can't convert from {tensor.normalization} to norm255")


### PR DESCRIPTION
- ***Mean_std_norm no more uses resnet normalization and can be used for custom normalization :***

Before, mean_std_norm used _resnet_mean_std by default, therefore you could only use resnet normalization. Now you can use any custom normalization. 

```
import torch
import aloscene

x=torch.rand(3,600,600)
x=aloscene.Frame(x,mean_std=((0.333,0.333,0.333),(0.333,0.333,0.333)))
print("normalization de x ",x.normalization)
print("Mean_std de x",x.mean_std)

x=x.mean_std_norm(mean=(0.440,0.220,0.880), std=(0.333,0.333,0.333), name="my_norm")
print("normalization de x ",x.normalization)
print("Mean_std de x",x.mean_std)
```
Output :
```
normalization de x  255
Mean_std de x ((0.333, 0.333, 0.333), (0.333, 0.333, 0.333))
normalization de x  my_norm
Mean_std de x ((0.44, 0.22, 0.88), (0.333, 0.333, 0.333))


```

- ***Conversion from mean_std_norm to minmax_sym and from minmax_sym to mean_std_norm***
Added this conversion which raised an Exception before

```
import torch
import aloscene

x=torch.rand(3,600,600)
x=aloscene.Frame(x,mean_std=((0.333,0.333,0.333),(0.333,0.333,0.333)))
x = x.norm_minmax_sym()
print("normalization de x ",x.normalization)
print("Mean_std de x",x.mean_std)
x = x.mean_std_norm(mean=(0.333,0.333,0.333), std=(0.333,0.333,0.333), name="custom")  # Exception raised
print("normalization de x ",x.normalization)
print("Mean_std de x",x.mean_std)
```

Output : 
```
normalization de x  minmax_sym
Mean_std de x None
normalization de x  custom
Mean_std de x ((0.333, 0.333, 0.333), (0.333, 0.333, 0.333))
```

_____
This pull request includes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
