### PR TITLE
feat -detr exportation- include preprocessing

### DIFF
--- a/alonet/deformable_detr/README.md
+++ b/alonet/deformable_detr/README.md
@@ -61,5 +61,10 @@ Evaluation on 1000 images COCO with box refinement
 
 ## Exportation
 ```bash
-python trt_exporter.py --refinement --HW 320 480 --verbose --ignore_adapt_graph
+python trt_exporter.py --refinement --HW 320 480 --verbose
+```
+or (for preprocessing included)
+
+```bash
+python trt_exporter.py --refinement --HW 320 480 --verbose
 ```

--- a/alonet/deformable_detr/deformable_detr.py
+++ b/alonet/deformable_detr/deformable_detr.py
@@ -240,7 +240,6 @@ class DeformableDETR(nn.Module):
             - :attr:`enc_outputs`: Optional, only returned when transformer encoder outputs are activated.
             - :attr:`dec_outputs`: Optional, only returned when transformer decoder outputs are activated.
         """
-        assert next(self.parameters()).is_cuda, "DeformableDETR cannot run on CPU (due to MSdeformable op)"
 
         if self.tracing:
             if self.include_preprocessing:
@@ -252,6 +251,7 @@ class DeformableDETR(nn.Module):
                 frame_masks = frame_masks.to(frames.device)
             frames = torch.cat([frames, frame_masks], dim=1)
         else:
+            assert next(self.parameters()).is_cuda, "DeformableDETR cannot run on CPU (due to MSdeformable op)"
             frame_masks = frames.mask.as_tensor()
 
         # ==== Backbone

--- a/alonet/detr/misc.py
+++ b/alonet/detr/misc.py
@@ -14,7 +14,6 @@ def assert_and_export_onnx(check_mean_std=False, input_mean_std=None):
             # because torch.onnx.export accepts only torch.Tensor or None
             if hasattr(instance, "tracing") and instance.tracing:
                 assert isinstance(frames, torch.Tensor)
-                assert frames.shape[1] == 4  # rgb 3 + mask 1
                 kwargs["is_tracing"] = None
                 if is_export_onnx is None:
                     return forward(instance, frames, is_export_onnx=None, **kwargs)


### PR DESCRIPTION
* ***New feature*** : Include image preprocessing in detr exportation 
```bash
## Exportation example
python alonet/deformable_detr/trt_exporter.py --refinement --HW 320 480--include_preprocessing 
```

_____
This pull request includes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
