### PR TITLE
Some features that I needed when working on deformableDETR

### DIFF
--- a/alonet/deformable_detr/deformable_detr.py
+++ b/alonet/deformable_detr/deformable_detr.py
@@ -105,7 +105,6 @@ class DeformableDETR(nn.Module):
         self.background_class = num_classes if self.activation_fn == "softmax" else None
         num_classes += 1 if self.activation_fn == "softmax" else 0  # Add bg class
 
-
         # Projection for Multi-scale features
         if num_feature_levels > 1:
             num_backbone_outs = len(backbone.strides) - 1  # Ignore backbone.layer1
@@ -618,7 +617,7 @@ class DeformableDETR(nn.Module):
             n_points=dec_n_points,
         )
 
-    def build_decoder(self, hidden_dim=256, num_feature_levels=4, dec_layers: int = 6, return_intermediate_dec: bool = True):
+    def build_decoder(self, dec_layers: int = 6, return_intermediate_dec: bool = True, hidden_dim: int = 256, num_feature_levels: int = 4):
         """Build decoder layer
 
         Parameters

--- a/alonet/deformable_detr/deformable_detr.py
+++ b/alonet/deformable_detr/deformable_detr.py
@@ -618,11 +618,15 @@ class DeformableDETR(nn.Module):
             n_points=dec_n_points,
         )
 
-    def build_decoder(self, dec_layers: int = 6, return_intermediate_dec: bool = True):
+    def build_decoder(self, hidden_dim=256, num_feature_levels=4, dec_layers: int = 6, return_intermediate_dec: bool = True):
         """Build decoder layer
 
         Parameters
         ----------
+        hidden_dim : int, optional
+            Hidden dimension size, by default 256
+        num_feature_levels : int, optional
+            Number of feature levels, by default 4
         dec_layers : int, optional
             Number of decoder layers, by default 6
         return_intermediate_dec : bool, optional
@@ -633,7 +637,7 @@ class DeformableDETR(nn.Module):
         :class:`~alonet.deformable.deformable_transformer.DeformableTransformerDecoder`
             Transformer decoder
         """
-        decoder_layer = self.build_decoder_layer()
+        decoder_layer = self.build_decoder_layer(hidden_dim=hidden_dim, num_feature_levels=num_feature_levels)
 
         return DeformableTransformerDecoder(decoder_layer, dec_layers, return_intermediate_dec)
 
@@ -680,7 +684,7 @@ class DeformableDETR(nn.Module):
         :mod:`Transformer <alonet.detr.transformer>`
             Transformer module
         """
-        decoder = self.build_decoder()
+        decoder = self.build_decoder(hidden_dim=hidden_dim, num_feature_levels=num_feature_levels)
 
         return DeformableTransformer(
             decoder=decoder,

--- a/alonet/deformable_detr/deformable_detr.py
+++ b/alonet/deformable_detr/deformable_detr.py
@@ -90,7 +90,7 @@ class DeformableDETR(nn.Module):
         super().__init__()
         self.device = device
         self.num_feature_levels = num_feature_levels
-        self.transformer = transformer
+        self.backbone = backbone
         self.num_queries = num_queries
         self.return_intermediate_dec = return_intermediate_dec
         self.hidden_dim = transformer.d_model
@@ -105,9 +105,7 @@ class DeformableDETR(nn.Module):
         self.background_class = num_classes if self.activation_fn == "softmax" else None
         num_classes += 1 if self.activation_fn == "softmax" else 0  # Add bg class
 
-        self.class_embed = nn.Linear(self.hidden_dim, num_classes)
-        self.bbox_embed = MLP(self.hidden_dim, self.hidden_dim, 4, 3)
-        self.query_embed = nn.Embedding(num_queries, self.hidden_dim * 2)
+
         # Projection for Multi-scale features
         if num_feature_levels > 1:
             num_backbone_outs = len(backbone.strides) - 1  # Ignore backbone.layer1
@@ -138,8 +136,11 @@ class DeformableDETR(nn.Module):
                     )
                 ]
             )
+        self.query_embed = nn.Embedding(num_queries, self.hidden_dim * 2)
+        self.transformer = transformer
+        self.class_embed = nn.Linear(self.hidden_dim, num_classes)
+        self.bbox_embed = MLP(self.hidden_dim, self.hidden_dim, 4, 3)
 
-        self.backbone = backbone
         self.aux_loss = aux_loss
         self.with_box_refine = with_box_refine
         self.tracing = tracing

--- a/alonet/detr/data_modules/coco_detection2detr.py
+++ b/alonet/detr/data_modules/coco_detection2detr.py
@@ -99,12 +99,7 @@ if __name__ == "__main__":
     coco = CocoDetection2Detr(args, **loader_kwargs)
     coco.prepare_data()
     coco.setup()
-    iterator=iter(coco.train_dataloader())
+    iterator = iter(coco.train_dataloader())
     for i in range(2):
         samples = next(iterator)
         samples[0].get_view().render()
-    # samples = next()
-    # samples[0].get_view().render()
-
-    # samples = next(iter(coco.val_dataloader()))
-    # samples[0].get_view().render()

--- a/alonet/detr/data_modules/coco_detection2detr.py
+++ b/alonet/detr/data_modules/coco_detection2detr.py
@@ -88,20 +88,23 @@ class CocoDetection2Detr(Data2Detr):
 if __name__ == "__main__":
     # setup data
     loader_kwargs = dict(
-        name="rabbits",
-        train_folder="train",
-        train_ann="train/_annotations.coco.json",
-        val_folder="valid",
-        val_ann="valid/_annotations.coco.json",
+        name="coco",
+        train_folder="train2017",
+        train_ann="annotations/instances_train2017.json",
+        val_folder="val2017",
+        val_ann="annotations/instances_val2017.json",
     )
 
     args = CocoDetection2Detr.add_argparse_args(ArgumentParser()).parse_args()  # Help provider
     coco = CocoDetection2Detr(args, **loader_kwargs)
     coco.prepare_data()
     coco.setup()
+    iterator=iter(coco.train_dataloader())
+    for i in range(2):
+        samples = next(iterator)
+        samples[0].get_view().render()
+    # samples = next()
+    # samples[0].get_view().render()
 
-    samples = next(iter(coco.train_dataloader()))
-    samples[0].get_view().render()
-
-    samples = next(iter(coco.val_dataloader()))
-    samples[0].get_view().render()
+    # samples = next(iter(coco.val_dataloader()))
+    # samples[0].get_view().render()

--- a/alonet/detr/data_modules/data2detr.py
+++ b/alonet/detr/data_modules/data2detr.py
@@ -16,6 +16,7 @@ import pytorch_lightning as pl
 
 import alonet
 import aloscene
+from torch.utils.data.sampler import RandomSampler, SequentialSampler
 
 
 class Data2Detr(pl.LightningDataModule):
@@ -122,6 +123,9 @@ class Data2Detr(pl.LightningDataModule):
         parser.add_argument(
             "--sample", action="store_true", help="Download a sample for train/val process (Default: %(default)s)"
         )
+        parser.add_argument(
+            "--sequential", action="store_true", help="Use sequential loading for train (Default: %(default)s)"
+        )
         return parent_parser
 
     def train_transform(self, frame: aloscene.Frame, same_on_sequence: bool = True, same_on_frames: bool = False):
@@ -217,7 +221,10 @@ class Data2Detr(pl.LightningDataModule):
         torch.utils.data.DataLoader
             Dataloader for training process
         """
-        return self.train_dataset.train_loader(batch_size=self.batch_size, num_workers=self.num_workers)
+        return self.train_dataset.train_loader(
+            batch_size=self.batch_size,
+            num_workers=self.num_workers,
+            sampler=SequentialSampler if self.sequential else RandomSampler)
 
     def val_dataloader(self, sampler: torch.utils.data = None):
         """Get val dataloader

--- a/alonet/detr/detr.py
+++ b/alonet/detr/detr.py
@@ -92,8 +92,6 @@ class Detr(nn.Module):
         self.background_class = self.num_classes if background_class is None else background_class
         self.num_classes += 1
 
-
-
         self.class_embed = self.build_class_embed()
         self.bbox_embed = self.build_bbox_embed()
 

--- a/alonet/detr/detr.py
+++ b/alonet/detr/detr.py
@@ -74,7 +74,12 @@ class Detr(nn.Module):
         tracing: bool = False,
     ):
         super().__init__()
+        self.backbone = backbone
         self.num_queries = num_queries
+        hidden_dim = transformer.d_model
+        self.hidden_dim = hidden_dim
+        self.query_embed = nn.Embedding(num_queries, hidden_dim)
+        self.input_proj = nn.Conv2d(backbone.num_channels, hidden_dim, kernel_size=1)
         self.transformer = transformer
         self.num_decoder_layers = transformer.decoder.num_layers
         self.num_classes = num_classes
@@ -87,15 +92,11 @@ class Detr(nn.Module):
         self.background_class = self.num_classes if background_class is None else background_class
         self.num_classes += 1
 
-        hidden_dim = transformer.d_model
-        self.hidden_dim = hidden_dim
+
 
         self.class_embed = self.build_class_embed()
         self.bbox_embed = self.build_bbox_embed()
 
-        self.query_embed = nn.Embedding(num_queries, hidden_dim)
-        self.input_proj = nn.Conv2d(backbone.num_channels, hidden_dim, kernel_size=1)
-        self.backbone = backbone
         self.aux_loss = aux_loss
         self.tracing = tracing
 

--- a/aloscene/mask.py
+++ b/aloscene/mask.py
@@ -234,3 +234,22 @@ class Mask(aloscene.tensors.SpatialAugmentedTensor):
         else:
             labels = [None] * len(self)
         return labels
+
+
+    def _spatial_shift(self, shift_y: float, shift_x: float, **kwargs):
+            """
+            Spatially shift the Mask.
+            This function is empty for now because the 1st implementation created issues.
+            The only purpose of this is to stop triggering the warning message.
+            Parameters
+            ----------
+            shift_y: float
+                Shift percentage on the y axis. Could be negative or positive
+            shift_x: float
+                Shift percentage on the x axis. Could ne negative or positive.
+            Returns
+            -------
+            shifted_tensor: aloscene.AugmentedTensor
+                shifted tensor
+            """
+            return self


### PR DESCRIPTION
Some features that I needed when working on deformableDETR

* ***New feature 1*** : Added "sequential" arg to Data2Detr datamodule
Uses sequential sampler for train_dataloader instead of random sampler. 
If you run this command, you should first see some lunchboxes with some broccoli inside, and then a flower bouquet.

```
python data_modules/coco_detection2detr.py --sequential
```
* ***New feature 2*** : The layers are instanciated in order in DETR and DeformableDETR
Before, when running "print(model)" on either of the models, the layers would be displayed out of order, which was confusing (i.e transformer before backbone). Now they are displayed in order. 

```
from argparse import ArgumentParser
from alonet.detr import LitDetr

import alonet


def get_arg_parser():
    parser = ArgumentParser(conflict_handler="resolve")
    parser = alonet.common.add_argparse_args(parser)  # Common alonet parser
    parser = LitDetr.add_argparse_args(parser)  # LitDetr training parser
    # parser = pl.Trainer.add_argparse_args(parser) # Pytorch lightning Parser
    return parser


def main():
    """Main"""
    # Build parser
    args = get_arg_parser().parse_args()  # Parse

    # Init the Detr model with the dataset
    detr = LitDetr(args)
    print(detr.model)

if __name__ == "__main__":
    main()
```
* ***New feature 3*** : Added spatial_shift to mask
The function is empty for now because its early implementation would trigger unforeseen bugs in DeformableDETR. However, having the function is necessary, because it triggers an error message instead when using Spatial Shift for data augmentation. 
If you run this example without the modification, you'll get a "raise Exception(f"This Augmented tensor {type(self)} should implement this method")". If you run the example with the modification, you'll get no errors. 

```
import aloscene
import torch
import alodataset.transforms as T

x=torch.zeros(3,256,256)
frame=aloscene.Frame(x,names=("C","H","W"))
mask=aloscene.Mask(torch.randint(0,2,(1,256,256)),names=("C","H","W"))
frame.append_mask(mask)

newframe=T.SpatialShift((10,10))(frame)
```
* ***New feature 4*** : Added a hidden_dim argument to build_decoder
I wanted to be able to reduce the hidden dimension of the transformer to make a lightweight model, but this dimension was hardcoded in the decoder. I added the argument to be able to change it.

```
from alonet.deformable_detr.deformable_detr import DeformableDETR
from alonet.deformable_detr.backbone import Joiner


class DeformableDetrCustom(DeformableDETR):
    """Deformable Detr with custom transformer. For testing purposes only"""

    def __init__(self, *args, hidden_dim=256, return_intermediate_dec: bool = True, num_classes=91, **kwargs):
        backbone = self.build_backbone(
            backbone_name="resnet50", train_backbone=True, return_interm_layers=True, dilation=False
        )
        position_embed = self.build_positional_encoding(hidden_dim=256)
        backbone = Joiner(backbone, position_embed)
        transformer = self.build_transformer(
            hidden_dim=hidden_dim,
            dropout=0.1,
            nheads=8,
            dim_feedforward=1024,
            enc_layers=6,
            dec_layers=6,
            num_feature_levels=4,
            dec_n_points=4,
            enc_n_points=4,
            return_intermediate_dec=return_intermediate_dec,
        )

        super().__init__(backbone, transformer, *args, num_classes=num_classes, with_box_refine=False, **kwargs)

if __name__ == "__main__":
    model=DeformableDetrCustom(weights=None)
    print(model.transformer.decoder.layers[0].cross_attn.sampling_offsets) #in_features should be 256

    model2=DeformableDetrCustom(hidden_dim=128,weights=None)
    print(model2.transformer.decoder.layers[0].cross_attn.sampling_offsets) #in_features should be 128
```

_____
This pull request includes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
