### PR TITLE
added .npz support to load_depth function

### DIFF
--- a/aloscene/io/depth.py
+++ b/aloscene/io/depth.py
@@ -8,12 +8,14 @@ def load_depth(path):
     Parameters
     ----------
     path: str
-        path to the disparity file. Supported format: {".npy"}. If your file is stored differently, as an
+        path to the disparity file. Supported format: {".npy",".npz"}. If your file is stored differently, as an
         alternative, you can open the file yourself and then create the Depth augmented Tensor from the depth
         data.
     """
     if path.endswith(".npy"):
         return np.load(path)
+    elif path.endswith(".npz"):
+        return np.load(path)["arr_0"]
     else:
         raise ValueError(
             f"Unknown extension for depth file: {path}. As an alternative you can load the file manually\

--- a/aloscene/io/depth.py
+++ b/aloscene/io/depth.py
@@ -15,7 +15,7 @@ def load_depth(path):
     if path.endswith(".npy"):
         return np.load(path)
     elif path.endswith(".npz"):
-        return np.load(path)["arr_0"]
+        return list(np.load(path).values())
     else:
         raise ValueError(
             f"Unknown extension for depth file: {path}. As an alternative you can load the file manually\

--- a/aloscene/io/depth.py
+++ b/aloscene/io/depth.py
@@ -15,7 +15,8 @@ def load_depth(path):
     if path.endswith(".npy"):
         return np.load(path)
     elif path.endswith(".npz"):
-        return list(np.load(path).values())
+        content = np.load(path)
+        return content[content.keys()[0]]
     else:
         raise ValueError(
             f"Unknown extension for depth file: {path}. As an alternative you can load the file manually\


### PR DESCRIPTION
Now you can also use this function to load depth saved as .npz. Based on the fix I made for MOTSynth dataset.

_____
This pull request includes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
