### PR TITLE
use p=1 by default for compose

### DIFF
--- a/alodataset/transforms.py
+++ b/alodataset/transforms.py
@@ -162,6 +162,8 @@ class Compose(AloTransform):
             List of transformation to apply sequentially
         """
         self.transforms = transforms
+        if "p" not in kwargs:
+            kwargs["p"] = 1.0
         super().__init__(*args, **kwargs)
 
     def sample_params(self):


### PR DESCRIPTION
Right now Compose has a probability of 0.5 by default causing very unintuive behavior (skipping all transforms half of the time).

I propose to replace to 1 by default with the option to change it.